### PR TITLE
feat: add Usage Finder component for crafting calculations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added Usage Finder tool (`#usage`) that lets players enter their metal inventory and discover every alloy and pure casting option available, with per-metal breakdowns, stack plans, and compatible fuels
+- Added "I have nuggets" / "I need ingots" mode toggle to the Alloying and Casting calculators so players can plan from either direction
+- Added `calculateAlloySplitFromNuggets` allocation algorithm that computes the maximum whole-ingot yield from available nuggets while respecting alloy percentage constraints
+- Added `mode-toggle.svelte` segmented-control component used by both calculators for switching calculation direction
+- Added shareable URLs for the Usage Finder and extended existing share codecs to encode the calculation mode and per-metal nugget counts
+
+### Changed
+
+- Replaced the two "More Tools Coming Soon" placeholders on the home page with the new Usage Finder card
+- Refactored the Casting calculator store to use a unified `inputValue` field instead of separate `targetIngots`, with a `mode` discriminator driving the derived calculation
+- Extended the Alloying calculator store with `metalNuggets` state and a "have" branch in the derived calculation that delegates to the new split-from-nuggets allocator
+- Widened the alloy results table to a six-column grid in "have" mode to show Available, Used, and Leftover columns
+
 ## [0.5.2] - 2026-03-28
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -37,11 +37,15 @@ Planned features and improvements include (but are not limited to):
 
 ### Alloying Calculator
 
-Calculate the exact amounts of metals needed to create your desired alloy. Supports all alloys and solders in Vintage Story. Includes smelting temperature information, a process-by-process stack plan view for multi-batch runs, and a share button that copies the current recipe URL.
+Calculate the exact amounts of metals needed to create your desired alloy. Supports all alloys and solders in Vintage Story. Switch between "I need ingots" and "I have nuggets" modes. The first mode calculates the required nuggets to produce the desired ingots, while the second mode figures out how many ingots you can produce from the nuggets on hand. Includes smelting temperature information, a process-by-process stack plan view for multi-batch runs, and a share button that copies the current recipe URL.
 
 ### Casting Calculator
 
-Calculate the number of ore nuggets needed to cast metal ingots in a crucible. Supports all 8 castable metals, shows smelting temperatures and ore source information, includes a visual stack plan for each smelting process, and supports shareable calculator URLs.
+Calculate the number of ore nuggets needed to cast metal ingots in a crucible. Supports all 8 castable metals, shows smelting temperatures and ore source information, includes a visual stack plan for each smelting process, and supports shareable calculator URLs. Also supports the "I have nuggets" mode to see how many ingots your stock produces.
+
+### Usage Finder
+
+Enter the metals you have and discover every alloy and casting option available to you. The tool checks your inventory against all game recipes, shows how many ingots each option yields, and provides a per-metal breakdown of nuggets used versus leftover. Expanding a result reveals the full stack plan and compatible fuels.
 
 ## Shareable Recipe URLs
 
@@ -49,7 +53,8 @@ Both calculators support URL-encoded state so you can share exact setups with ot
 
 - Use the `Share recipe` button in the calculator sidebar to copy the current setup URL.
 - Opening that URL restores calculator selections automatically.
-- URL format is route-aware, for example: `#alloying?a=tin_bronze&n=10&Copper=90.0&Tin=10.0` and `#casting?m=copper&n=10`.
+- URL format is route-aware, for example: `#alloying?a=tin_bronze&n=10&Copper=90.0&Tin=10.0`, `#casting?m=copper&n=10`, and `#usage?Copper=100&Tin=50`.
+- The "have" mode is encoded as `d=h` with per-metal nugget counts so shared links preserve the calculation direction.
 - The sharing system is extensible via per-route codecs registered through `src/lib/url-state.ts`.
 
 ### Feedback Form
@@ -65,6 +70,8 @@ Send feedback from a dedicated in-app page without creating an account. Submissi
 5. Optionally open settings from the header to customize theme, font family, UI scale, and help-text visibility
 6. For alloys: select your alloy type and adjust percentages to see exact nuggets needed
 7. For metals: select your metal and target ingots to see nuggets required
+8. Use the mode toggle to switch between "I need ingots" and "I have nuggets" in either calculator
+9. Use the Usage Finder to add metals from your inventory and see every recipe you can craft
 
 ## Development
 
@@ -85,6 +92,7 @@ VintageStoryCalculator/         # Root directory
 │   ├── components/             # Reusable UI components
 │   │   ├── calculator-card.svelte
 │   │   ├── feedback-form.svelte
+│   │   ├── mode-toggle.svelte
 │   │   ├── number-input.svelte
 │   │   ├── result-display.svelte
 │   │   ├── select-input.svelte
@@ -116,10 +124,12 @@ VintageStoryCalculator/         # Root directory
 │   │   ├── alloyCalculator.ts  # Alloying calculator store
 │   │   ├── metalCalculator.ts  # Casting calculator store
 │   │   ├── settings.ts         # Persistent UI settings store
+│   │   ├── usageFinder.ts      # Usage Finder inventory and results store
 │   │   ├── share/              # URL sharing codecs per calculator
 │   │   │   ├── alloyCodec.ts
 │   │   │   ├── index.ts
-│   │   │   └── metalCodec.ts
+│   │   │   ├── metalCodec.ts
+│   │   │   └── usageCodec.ts
 │   │   └── theme.ts            # Theme store
 │   ├── types/                  # Shared TypeScript interfaces
 │   │   ├── components.ts       # Component prop and event contracts
@@ -128,8 +138,9 @@ VintageStoryCalculator/         # Root directory
 │       ├── AlloyingCalculator.svelte
 │       ├── CastingCalculator.svelte
 │       ├── Feedback.svelte
+│       ├── Home.svelte
 │       ├── Privacy.svelte
-│       └── Home.svelte
+│       └── UsageFinder.svelte
 ├── tsconfig.json               # TypeScript configuration
 ├── .eslintrc.cjs               # ESLint configuration
 ├── styles/                     # Shared styling

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -4,6 +4,7 @@
   import Home from "./routes/Home.svelte";
   import AlloyingCalculator from "./routes/AlloyingCalculator.svelte";
   import CastingCalculator from "./routes/CastingCalculator.svelte";
+  import UsageFinder from "./routes/UsageFinder.svelte";
   import Feedback from "./routes/Feedback.svelte";
   import Privacy from "./routes/Privacy.svelte";
   import SettingsModal from "./components/settings-modal.svelte";
@@ -21,12 +22,13 @@
     { id: "home", label: "Home", hash: "#home" },
     { id: "alloying", label: "Alloying Calculator", hash: "#alloying" },
     { id: "casting", label: "Casting Calculator", hash: "#casting" },
+    { id: "usage", label: "Usage Finder", hash: "#usage" },
     { id: "feedback", label: "Feedback", hash: "#feedback" },
     { id: "privacy", label: "Privacy", hash: "#privacy" }
   ] as const;
 
   const CALCULATOR_NAV_ITEMS = NAV_ITEMS.filter(
-    (item) => item.id === "alloying" || item.id === "casting"
+    (item) => item.id === "alloying" || item.id === "casting" || item.id === "usage"
   );
 
   type RouteId = (typeof NAV_ITEMS)[number]["id"];
@@ -37,6 +39,7 @@
     home: Home,
     alloying: AlloyingCalculator,
     casting: CastingCalculator,
+    usage: UsageFinder,
     feedback: Feedback,
     privacy: Privacy
   };
@@ -50,6 +53,7 @@
     const route = parseRouteFromHash(hash);
     if (route === "alloying") return "alloying";
     if (route === "casting") return "casting";
+    if (route === "usage") return "usage";
     if (route === "feedback") return "feedback";
     if (route === "privacy") return "privacy";
     return "home";
@@ -78,6 +82,7 @@
       home: `${baseTitle} — Home`,
       alloying: `${baseTitle} — Alloying Calculator`,
       casting: `${baseTitle} — Casting Calculator`,
+      usage: `${baseTitle} — Usage Finder`,
       feedback: `${baseTitle} — Feedback`,
       privacy: `${baseTitle} — Privacy`
     };
@@ -88,6 +93,8 @@
         "Calculate exact metal ratios and nuggets for Vintage Story alloys like Tin Bronze, Bismuth Bronze, Electrum, and more.",
       casting:
         "Calculate ore nuggets needed to cast metal ingots in Vintage Story. Supports all castable metals including Copper, Gold, Silver, and more.",
+      usage:
+        "Enter the metals you have and discover every alloy and casting option available to you in Vintage Story.",
       feedback:
         "Send feedback for Vintage Story Calculator without creating an account. Report bugs, request features, and share ideas.",
       privacy:

--- a/src/components/mode-toggle.svelte
+++ b/src/components/mode-toggle.svelte
@@ -1,0 +1,34 @@
+<script lang="ts">
+  import { createEventDispatcher } from "svelte";
+  import type { CalculationMode } from "../types/index";
+
+  export let mode: CalculationMode = "need";
+
+  const dispatch = createEventDispatcher<{ change: { value: CalculationMode } }>();
+
+  const handleClick = (selected: CalculationMode) => {
+    if (selected === mode) return;
+    dispatch("change", { value: selected });
+  };
+</script>
+
+<div class="mode-toggle" role="radiogroup" aria-label="Calculation direction">
+  <button
+    type="button"
+    role="radio"
+    aria-checked={mode === "need"}
+    class:active={mode === "need"}
+    on:click={() => handleClick("need")}
+  >
+    I need ingots
+  </button>
+  <button
+    type="button"
+    role="radio"
+    aria-checked={mode === "have"}
+    class:active={mode === "have"}
+    on:click={() => handleClick("have")}
+  >
+    I have nuggets
+  </button>
+</div>

--- a/src/lib/smelting/allocation.ts
+++ b/src/lib/smelting/allocation.ts
@@ -2,6 +2,7 @@ import { NUGGETS_PER_INGOT, UNITS_PER_NUGGET } from "../constants";
 import type {
   AlloyAllocationResult,
   AlloyPartConstraint,
+  AlloySplitResult,
   PureAllocationResult
 } from "./types";
 
@@ -210,5 +211,113 @@ export const calculateAlloyAllocation = (
         pctActual: totalNuggets > 0 ? (nuggets / totalNuggets) * 100 : 0
       };
     })
+  };
+};
+
+export const calculateAlloySplitFromNuggets = (
+  availableNuggets: Record<string, number>,
+  parts: AlloyPartConstraint[]
+): AlloySplitResult => {
+  if (!parts.length) {
+    return {
+      totalNuggets: 0,
+      producedIngots: 0,
+      remainderNuggets: 0,
+      producedUnits: 0,
+      parts: []
+    };
+  }
+
+  const targetPercents = normalizeTargetPercents(parts);
+
+  let maxTotal = Number.POSITIVE_INFINITY;
+  for (let idx = 0; idx < parts.length; idx += 1) {
+    const part = parts[idx];
+    if (!part) continue;
+    const have = Math.max(0, availableNuggets[part.metal] ?? 0);
+    const pct = targetPercents[idx] ?? 0;
+    if (pct <= 0) continue;
+    maxTotal = Math.min(maxTotal, (have / pct) * 100);
+  }
+
+  if (!Number.isFinite(maxTotal) || maxTotal < 1) {
+    return {
+      totalNuggets: 0,
+      producedIngots: 0,
+      remainderNuggets: 0,
+      producedUnits: 0,
+      parts: parts.map((part) => ({
+        metal: part.metal,
+        color: part.color,
+        nuggets: 0,
+        units: 0,
+        available: Math.max(0, availableNuggets[part.metal] ?? 0),
+        leftover: Math.max(0, availableNuggets[part.metal] ?? 0),
+        min: part.min,
+        max: part.max,
+        pctTarget: 0,
+        pctActual: 0
+      }))
+    };
+  }
+
+  let usableTotal = Math.floor(maxTotal / NUGGETS_PER_INGOT) * NUGGETS_PER_INGOT;
+
+  while (usableTotal >= NUGGETS_PER_INGOT) {
+    const bounds = buildBounds(usableTotal, parts);
+    if (isFeasibleTotal(usableTotal, bounds)) {
+      const allocation = allocateWithinBounds(usableTotal, bounds, targetPercents);
+      const allFit = parts.every((part, idx) => {
+        const used = allocation[idx] ?? 0;
+        const have = Math.max(0, availableNuggets[part.metal] ?? 0);
+        return used <= have;
+      });
+      if (allFit) {
+        const producedIngots = usableTotal / NUGGETS_PER_INGOT;
+        return {
+          totalNuggets: usableTotal,
+          producedIngots,
+          remainderNuggets: 0,
+          producedUnits: usableTotal * UNITS_PER_NUGGET,
+          parts: parts.map((part, idx) => {
+            const nuggets = allocation[idx] ?? 0;
+            const have = Math.max(0, availableNuggets[part.metal] ?? 0);
+            const pctTarget = targetPercents[idx] ?? 0;
+            return {
+              metal: part.metal,
+              color: part.color,
+              nuggets,
+              units: nuggets * UNITS_PER_NUGGET,
+              available: have,
+              leftover: have - nuggets,
+              min: part.min,
+              max: part.max,
+              pctTarget,
+              pctActual: usableTotal > 0 ? (nuggets / usableTotal) * 100 : 0
+            };
+          })
+        };
+      }
+    }
+    usableTotal -= NUGGETS_PER_INGOT;
+  }
+
+  return {
+    totalNuggets: 0,
+    producedIngots: 0,
+    remainderNuggets: 0,
+    producedUnits: 0,
+    parts: parts.map((part) => ({
+      metal: part.metal,
+      color: part.color,
+      nuggets: 0,
+      units: 0,
+      available: Math.max(0, availableNuggets[part.metal] ?? 0),
+      leftover: Math.max(0, availableNuggets[part.metal] ?? 0),
+      min: part.min,
+      max: part.max,
+      pctTarget: 0,
+      pctActual: 0
+    }))
   };
 };

--- a/src/lib/smelting/types.ts
+++ b/src/lib/smelting/types.ts
@@ -42,6 +42,23 @@ export type AlloyAllocationResult = {
   >;
 };
 
+export type AlloySplitPart = MetalAllocation & {
+  available: number;
+  leftover: number;
+  min: number;
+  max: number;
+  pctTarget: number;
+  pctActual: number;
+};
+
+export type AlloySplitResult = {
+  totalNuggets: number;
+  producedIngots: number;
+  remainderNuggets: number;
+  producedUnits: number;
+  parts: AlloySplitPart[];
+};
+
 export type SmeltingPlannerOptions = {
   alloyParts?: AlloyPartConstraint[];
   enforceMinProcessNuggets?: number;

--- a/src/routes/AlloyingCalculator.svelte
+++ b/src/routes/AlloyingCalculator.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import CalculatorCard from "../components/calculator-card.svelte";
+  import ModeToggle from "../components/mode-toggle.svelte";
   import NumberInput from "../components/number-input.svelte";
   import SelectInput from "../components/select-input.svelte";
   import ShareButton from "../components/share-button.svelte";
@@ -12,11 +13,13 @@
     ALLOY_PERCENT_STEP,
     alloyCalculation,
     alloyCalculator,
+    setMetalNuggets,
     setMetalPercentage,
+    setMode,
     setSelectedAlloy,
     setTargetIngots
   } from "../stores/alloyCalculator";
-  import type { Alloy } from "../types/index";
+  import type { CalculationMode, Alloy } from "../types/index";
   import type { SelectOption } from "../types/components";
 
   const alloys = alloyDefinitionsRaw as Record<string, Alloy>;
@@ -33,6 +36,10 @@
     setSelectedAlloy(event.detail.value);
   };
 
+  const handleModeChange = (event: CustomEvent<{ value: CalculationMode }>) => {
+    setMode(event.detail.value);
+  };
+
   const handleIngotsInput = (event: CustomEvent<{ value: number | null }>) => {
     setTargetIngots(event.detail.value);
   };
@@ -43,6 +50,10 @@
     if (!Number.isFinite(value)) return;
     setMetalPercentage(metal, value);
   };
+
+  const handleNuggetInput = (metal: string, event: CustomEvent<{ value: number | null }>) => {
+    setMetalNuggets(metal, event.detail.value ?? 0);
+  };
 </script>
 
 <section class="calculator-shell">
@@ -52,12 +63,19 @@
       subtitle="Blend planning"
     >
       <p>
-        Calculate exact metal amounts for each alloy recipe. One ingot equals
-        {NUGGETS_PER_INGOT} nuggets.
+        {#if $alloyCalculator.mode === "have"}
+          Enter the nuggets you have for each metal and see how many ingots you can produce.
+          One ingot equals {NUGGETS_PER_INGOT} nuggets.
+        {:else}
+          Calculate exact metal amounts for each alloy recipe. One ingot equals
+          {NUGGETS_PER_INGOT} nuggets.
+        {/if}
       </p>
     </CalculatorCard>
 
     <div class="controls">
+      <ModeToggle mode={$alloyCalculator.mode} on:change={handleModeChange} />
+
       <SelectInput
         id="alloySelect"
         label="Choose alloy"
@@ -67,23 +85,44 @@
         on:change={handleAlloyChange}
       />
 
-      <NumberInput
-        id="targetIngots"
-        label="Target ingots"
-        value={$alloyCalculator.targetIngots}
-        min={0}
-        step={1}
-        helpText="Total ingots to produce."
-        on:input={handleIngotsInput}
-      />
+      {#if $alloyCalculator.mode === "have"}
+        {#each $alloyCalculation.parts as part}
+          <NumberInput
+            id="nuggets_{part.metal}"
+            label="{part.metal} nuggets"
+            value={$alloyCalculator.metalNuggets[part.metal] ?? 0}
+            min={0}
+            step={1}
+            helpText="Nuggets of {part.metal} you have."
+            on:input={(e) => handleNuggetInput(part.metal, e)}
+          />
+        {/each}
+      {:else}
+        <NumberInput
+          id="targetIngots"
+          label="Target ingots"
+          value={$alloyCalculator.targetIngots}
+          min={0}
+          step={1}
+          helpText="Total ingots to produce."
+          on:input={handleIngotsInput}
+        />
+      {/if}
     </div>
 
     <CalculatorCard title="Quick Summary" headingTag="h3">
       <div class="calculator-meta-grid">
-        <p class="calculator-meta-item">
-          <span>Total units</span>
-          <strong>{formatQuantity($alloyCalculation.totalUnits)}</strong>
-        </p>
+        {#if $alloyCalculator.mode === "have"}
+          <p class="calculator-meta-item">
+            <span>Ingots produced</span>
+            <strong>{formatQuantity($alloyCalculation.producedIngots)}</strong>
+          </p>
+        {:else}
+          <p class="calculator-meta-item">
+            <span>Total units</span>
+            <strong>{formatQuantity($alloyCalculation.totalUnits)}</strong>
+          </p>
+        {/if}
         <p class="calculator-meta-item">
           <span>Smelting temp</span>
           <strong>{$alloyCalculation.smeltTemp}</strong>
@@ -99,14 +138,20 @@
   </aside>
 
   <section class="calculator-workspace" aria-label="Alloy recipe results">
-    <div id="calculator" class="calculator-main">
+      <div id="calculator" class="calculator-main" class:calc-six-cols={$alloyCalculator.mode === "have"}>
       <table aria-label="Alloy recipe">
         <thead>
           <tr>
             <th>Metal</th>
             <th title="Target percent range for each metal.">Recipe %</th>
-            <th title="Units required to hit the target ingots.">Units needed</th>
-            <th title="Total nuggets required for each metal.">Nuggets</th>
+            {#if $alloyCalculator.mode === "have"}
+              <th title="Nuggets available for each metal.">Available</th>
+              <th title="Nuggets used in the alloy.">Used</th>
+              <th title="Nuggets remaining after alloying.">Leftover</th>
+            {:else}
+              <th title="Units required to hit the target ingots.">Units needed</th>
+              <th title="Total nuggets required for each metal.">Nuggets</th>
+            {/if}
             <th title="Fine-tune the percent with a slider.">Adjust</th>
           </tr>
         </thead>
@@ -129,8 +174,14 @@
                   on:change={(event) => handlePercentInput(part.metal, event)}
                 />
               </td>
-              <td class="units" data-label="Units needed">{formatQuantity(part.units)}</td>
-              <td class="nuggets" data-label="Nuggets">{formatQuantity(part.nuggets)}</td>
+              {#if $alloyCalculator.mode === "have"}
+                <td class="nuggets" data-label="Available">{formatQuantity(part.available ?? 0)}</td>
+                <td class="nuggets" data-label="Used">{formatQuantity(part.nuggets)}</td>
+                <td class="nuggets" data-label="Leftover">{formatQuantity(part.leftover ?? 0)}</td>
+              {:else}
+                <td class="units" data-label="Units needed">{formatQuantity(part.units)}</td>
+                <td class="nuggets" data-label="Nuggets">{formatQuantity(part.nuggets)}</td>
+              {/if}
               <td class="sliders" data-label="Adjust">
                 <input
                   class="slider"

--- a/src/routes/CastingCalculator.svelte
+++ b/src/routes/CastingCalculator.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import CalculatorCard from "../components/calculator-card.svelte";
+  import ModeToggle from "../components/mode-toggle.svelte";
   import NumberInput from "../components/number-input.svelte";
   import SelectInput from "../components/select-input.svelte";
   import ShareButton from "../components/share-button.svelte";
@@ -10,10 +11,11 @@
   import {
     metalCalculation,
     metalCalculator,
-    setSelectedMetal,
-    setTargetIngots
+    setInputValue,
+    setMode,
+    setSelectedMetal
   } from "../stores/metalCalculator";
-  import type { Metal } from "../types/index";
+  import type { CalculationMode, Metal } from "../types/index";
   import type { SelectOption } from "../types/components";
 
   const metalDefinitions = metalDefinitionsRaw as Record<string, Metal>;
@@ -30,8 +32,12 @@
     setSelectedMetal(event.detail.value);
   };
 
-  const handleIngotsInput = (event: CustomEvent<{ value: number | null }>) => {
-    setTargetIngots(event.detail.value);
+  const handleModeChange = (event: CustomEvent<{ value: CalculationMode }>) => {
+    setMode(event.detail.value);
+  };
+
+  const handleValueInput = (event: CustomEvent<{ value: number | null }>) => {
+    setInputValue(event.detail.value);
   };
 </script>
 
@@ -42,12 +48,19 @@
       subtitle="Ore to ingot planning"
     >
       <p>
-        Calculate ore nuggets required for your target ingot count. Each ingot uses
-        {NUGGETS_PER_INGOT} nuggets ({UNITS_PER_INGOT} units).
+        {#if $metalCalculator.mode === "have"}
+          See how many ingots you can cast from your available nuggets. Each ingot uses
+          {NUGGETS_PER_INGOT} nuggets ({UNITS_PER_INGOT} units).
+        {:else}
+          Calculate ore nuggets required for your target ingot count. Each ingot uses
+          {NUGGETS_PER_INGOT} nuggets ({UNITS_PER_INGOT} units).
+        {/if}
       </p>
     </CalculatorCard>
 
     <div class="controls">
+      <ModeToggle mode={$metalCalculator.mode} on:change={handleModeChange} />
+
       <SelectInput
         id="metalSelect"
         label="Choose metal"
@@ -57,23 +70,46 @@
         on:change={handleMetalChange}
       />
 
-      <NumberInput
-        id="targetIngots"
-        label="Target ingots"
-        value={$metalCalculator.targetIngots}
-        min={0}
-        step={1}
-        helpText="Total ingots to cast."
-        on:input={handleIngotsInput}
-      />
+      {#if $metalCalculator.mode === "have"}
+        <NumberInput
+          id="availableNuggets"
+          label="Available nuggets"
+          value={$metalCalculator.inputValue}
+          min={0}
+          step={1}
+          helpText="How many nuggets you have."
+          on:input={handleValueInput}
+        />
+      {:else}
+        <NumberInput
+          id="targetIngots"
+          label="Target ingots"
+          value={$metalCalculator.inputValue}
+          min={0}
+          step={1}
+          helpText="Total ingots to cast."
+          on:input={handleValueInput}
+        />
+      {/if}
     </div>
 
     <CalculatorCard title="Quick Summary" headingTag="h3">
       <div class="calculator-meta-grid">
-        <p class="calculator-meta-item">
-          <span>Nuggets needed</span>
-          <strong>{formatQuantity($metalCalculation.nuggetsNeeded)}</strong>
-        </p>
+        {#if $metalCalculator.mode === "have"}
+          <p class="calculator-meta-item">
+            <span>Ingots produced</span>
+            <strong>{formatQuantity($metalCalculation.producedIngots)}</strong>
+          </p>
+          <p class="calculator-meta-item">
+            <span>Leftover nuggets</span>
+            <strong>{formatQuantity($metalCalculation.remainderNuggets)}</strong>
+          </p>
+        {:else}
+          <p class="calculator-meta-item">
+            <span>Nuggets needed</span>
+            <strong>{formatQuantity($metalCalculation.nuggetsNeeded)}</strong>
+          </p>
+        {/if}
         <p class="calculator-meta-item">
           <span>Smelting temp</span>
           <strong>{$metalCalculation.smeltTemp}</strong>

--- a/src/routes/Home.svelte
+++ b/src/routes/Home.svelte
@@ -36,24 +36,13 @@
       </div>
       <span class="tool-arrow" aria-hidden="true">→</span>
     </a>
-    <a href="#coming-soon" class="tool-card tool-coming-soon">
-      <div class="tool-icon" aria-hidden="true">⏳</div>
+    <a href="#usage" class="tool-card">
+      <div class="tool-icon" aria-hidden="true">🔍</div>
       <div class="tool-body">
-        <h3>More Tools Coming Soon</h3>
+        <h3>Usage Finder</h3>
         <p>
-          I'm planning more calculators and utilities to help with resource planning, smelting
-          optimization, and more. Stay tuned!
-        </p>
-      </div>
-      <span class="tool-arrow" aria-hidden="true">→</span>
-    </a>
-    <a href="#coming-soon" class="tool-card tool-coming-soon">
-      <div class="tool-icon" aria-hidden="true">🧪</div>
-      <div class="tool-body">
-        <h3>More Tools Coming Soon</h3>
-        <p>
-          I'm planning more calculators and utilities to help with resource planning, smelting
-          optimization, and more. Stay tuned!
+          Enter the metals you have and discover every alloy and casting option
+          available to you.
         </p>
       </div>
       <span class="tool-arrow" aria-hidden="true">→</span>

--- a/src/routes/UsageFinder.svelte
+++ b/src/routes/UsageFinder.svelte
@@ -1,0 +1,181 @@
+<script lang="ts">
+  import CalculatorCard from "../components/calculator-card.svelte";
+  import NumberInput from "../components/number-input.svelte";
+  import SelectInput from "../components/select-input.svelte";
+  import ShareButton from "../components/share-button.svelte";
+  import StackPlanPanel from "../components/stack-plan-panel.svelte";
+  import { NUGGETS_PER_INGOT } from "../lib/constants";
+  import { formatWholeNumber } from "../lib/numberFormatting";
+  import {
+    addMetal,
+    allMetalKeys,
+    getMetalName,
+    removeMetal,
+    setNuggets,
+    toggleExpanded,
+    usageFinder,
+    usageFinderResults
+  } from "../stores/usageFinder";
+  import type { SelectOption } from "../types/components";
+
+  const formatQuantity = formatWholeNumber;
+
+  $: usedKeys = new Set($usageFinder.inventory.map((e) => e.metalKey));
+  $: availableOptions = allMetalKeys
+    .filter((key) => !usedKeys.has(key))
+    .map((key): SelectOption<string> => ({ value: key, label: getMetalName(key) }));
+
+  let addSelectValue = "";
+
+  const handleAddMetal = (event: CustomEvent<{ value: string }>) => {
+    const key = event.detail.value;
+    if (!key) return;
+    addMetal(key);
+    addSelectValue = "";
+  };
+
+  const handleNuggetInput = (metalKey: string, event: CustomEvent<{ value: number | null }>) => {
+    setNuggets(metalKey, event.detail.value ?? 0);
+  };
+
+  const handleRemove = (metalKey: string) => {
+    removeMetal(metalKey);
+  };
+
+  const handleToggle = (key: string) => {
+    toggleExpanded(key);
+  };
+</script>
+
+<section class="calculator-shell">
+  <aside class="calculator-rail" aria-label="Usage Finder controls">
+    <CalculatorCard
+      title="Usage Finder"
+      subtitle="What can I make?"
+    >
+      <p>
+        Add the metals you have and see everything you can craft. One ingot
+        equals {NUGGETS_PER_INGOT} nuggets.
+      </p>
+    </CalculatorCard>
+
+    <div class="controls">
+      {#each $usageFinder.inventory as entry (entry.metalKey)}
+        <div class="inventory-row">
+          <div class="inventory-input">
+            <NumberInput
+              id="inv_{entry.metalKey}"
+              label="{getMetalName(entry.metalKey)} nuggets"
+              value={entry.nuggets}
+              min={0}
+              step={1}
+              helpText=""
+              on:input={(e) => handleNuggetInput(entry.metalKey, e)}
+            />
+          </div>
+          <button
+            class="inventory-remove"
+            type="button"
+            aria-label="Remove {getMetalName(entry.metalKey)}"
+            title="Remove {getMetalName(entry.metalKey)}"
+            on:click={() => handleRemove(entry.metalKey)}
+          >×</button>
+        </div>
+      {/each}
+
+      {#if availableOptions.length > 0}
+        <SelectInput
+          id="addMetal"
+          label="Add metal"
+          options={[{ value: "", label: "Select a metal…" }, ...availableOptions]}
+          value={addSelectValue}
+          helpText=""
+          on:change={handleAddMetal}
+        />
+      {/if}
+    </div>
+
+    <CalculatorCard title="Quick Summary" headingTag="h3">
+      <div class="calculator-meta-grid">
+        <p class="calculator-meta-item">
+          <span>Metals added</span>
+          <strong>{$usageFinder.inventory.length}</strong>
+        </p>
+        <p class="calculator-meta-item">
+          <span>Total nuggets</span>
+          <strong>{formatQuantity($usageFinder.inventory.reduce((sum, e) => sum + e.nuggets, 0))}</strong>
+        </p>
+      </div>
+    </CalculatorCard>
+
+    <ShareButton route="usage" />
+  </aside>
+
+  <section class="calculator-workspace" aria-label="Usage Finder results">
+    <div class="calculator-main usage-results">
+      {#if $usageFinder.inventory.length === 0}
+        <div class="usage-empty">
+          <p>Add metals above to see what you can make.</p>
+        </div>
+      {:else if $usageFinderResults.length === 0}
+        <div class="usage-empty">
+          <p>Not enough nuggets for any recipe. You need at least {NUGGETS_PER_INGOT} nuggets of any metal.</p>
+        </div>
+      {:else}
+        {#each $usageFinderResults as result (result.key)}
+          <button
+            class="result-card"
+            class:result-card--expanded={$usageFinder.expandedResults.has(result.key)}
+            type="button"
+            aria-expanded={$usageFinder.expandedResults.has(result.key)}
+            on:click={() => handleToggle(result.key)}
+          >
+            <div class="result-header">
+              <span class="result-name">{result.name}</span>
+              <span class="result-badge">{result.ingots} ingot{result.ingots !== 1 ? "s" : ""}</span>
+              <span class="result-summary">{result.leftoverNuggets} leftover nugget{result.leftoverNuggets !== 1 ? "s" : ""}</span>
+              <span class="result-chevron" aria-hidden="true">{$usageFinder.expandedResults.has(result.key) ? "▾" : "▸"}</span>
+            </div>
+
+            {#if $usageFinder.expandedResults.has(result.key)}
+              <!-- svelte-ignore a11y-no-static-element-interactions -->
+              <div class="result-details" on:click|stopPropagation on:keydown|stopPropagation>
+                <table class="result-breakdown" aria-label="{result.name} breakdown">
+                  <thead>
+                    <tr>
+                      <th>Metal</th>
+                      <th>Available</th>
+                      <th>Used</th>
+                      <th>Leftover</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {#each result.details as detail}
+                      <tr>
+                        <td>{detail.metal}</td>
+                        <td>{formatQuantity(detail.available)}</td>
+                        <td>{formatQuantity(detail.used)}</td>
+                        <td>{formatQuantity(detail.leftover)}</td>
+                      </tr>
+                    {/each}
+                  </tbody>
+                </table>
+
+                <div class="result-meta">
+                  <span><strong>Smelting temp:</strong> {result.smeltTemp}</span>
+                  <span><strong>Fuels:</strong> {result.compatibleFuels}</span>
+                </div>
+
+                <StackPlanPanel
+                  stackPlan={result.stackPlan}
+                  hasStackInputs={result.hasStackInputs}
+                  {formatQuantity}
+                />
+              </div>
+            {/if}
+          </button>
+        {/each}
+      {/if}
+    </div>
+  </section>
+</section>

--- a/src/stores/alloyCalculator.ts
+++ b/src/stores/alloyCalculator.ts
@@ -1,6 +1,7 @@
 import { derived, writable } from "svelte/store";
 import alloyDefinitionsRaw from "../data/alloys.json";
 import {
+  NUGGETS_PER_INGOT,
   UNITS_PER_INGOT,
   formatTemperature,
   getMetalColor
@@ -12,13 +13,17 @@ import {
   type StackInput
 } from "../lib/stack-plan";
 import { formatFuelList, getCompatibleFuels } from "../lib/fuels";
-import { calculateAlloyAllocation } from "../lib/smelting";
-import type { Alloy } from "../types/index";
+import { calculateAlloyAllocation, calculateAlloySplitFromNuggets } from "../lib/smelting";
+import type { CalculationMode, Alloy } from "../types/index";
+
+const DEFAULT_HAVE_NUGGETS = 100;
 
 export type AlloyCalculatorState = {
   selectedAlloy: string;
+  mode: CalculationMode;
   targetIngots: number;
   metalPercentages: Record<string, number>;
+  metalNuggets: Record<string, number>;
 };
 
 type AlloyPartState = {
@@ -286,6 +291,14 @@ const partsToPercentages = (parts: AlloyPartState[]) => {
   return percentages;
 };
 
+const buildDefaultNuggets = (alloy: Alloy): Record<string, number> => {
+  const nuggets: Record<string, number> = {};
+  for (const part of alloy.parts) {
+    nuggets[part.metal] = DEFAULT_HAVE_NUGGETS;
+  }
+  return nuggets;
+};
+
 const initializeState = (): AlloyCalculatorState => {
   const alloyKeys = Object.keys(ALLOY_DEFINITIONS);
   const defaultAlloy = alloyKeys[0] ?? "";
@@ -293,8 +306,10 @@ const initializeState = (): AlloyCalculatorState => {
   const defaultParts = definition ? buildDefaultParts(definition) : [];
   return {
     selectedAlloy: defaultAlloy,
+    mode: "need",
     targetIngots: 10,
-    metalPercentages: partsToPercentages(defaultParts)
+    metalPercentages: partsToPercentages(defaultParts),
+    metalNuggets: definition ? buildDefaultNuggets(definition) : {}
   };
 };
 
@@ -307,8 +322,21 @@ export const setSelectedAlloy = (alloyKey: string) => {
   alloyCalculator.update((state) => ({
     ...state,
     selectedAlloy: alloyKey,
-    metalPercentages: partsToPercentages(defaultParts)
+    metalPercentages: partsToPercentages(defaultParts),
+    metalNuggets: buildDefaultNuggets(definition)
   }));
+};
+
+export const setMode = (mode: CalculationMode) => {
+  alloyCalculator.update((state) => {
+    if (state.mode === mode) return state;
+    const definition = getAlloyDefinition(state.selectedAlloy);
+    return {
+      ...state,
+      mode,
+      metalNuggets: definition ? buildDefaultNuggets(definition) : state.metalNuggets
+    };
+  });
 };
 
 export const setTargetIngots = (value: number | null) => {
@@ -341,6 +369,14 @@ export const setMetalPercentage = (metal: string, value: number) => {
   });
 };
 
+export const setMetalNuggets = (metal: string, value: number) => {
+  const safe = Math.max(0, Number(value) || 0);
+  alloyCalculator.update((state) => ({
+    ...state,
+    metalNuggets: { ...state.metalNuggets, [metal]: safe }
+  }));
+};
+
 export const applyState = (partial: Partial<AlloyCalculatorState>) => {
   alloyCalculator.update((state) => {
     const next = { ...state };
@@ -351,7 +387,12 @@ export const applyState = (partial: Partial<AlloyCalculatorState>) => {
         next.selectedAlloy = partial.selectedAlloy;
         const defaultParts = buildDefaultParts(def);
         next.metalPercentages = partsToPercentages(defaultParts);
+        next.metalNuggets = buildDefaultNuggets(def);
       }
+    }
+
+    if (partial.mode !== undefined) {
+      next.mode = partial.mode;
     }
 
     if (partial.targetIngots !== undefined) {
@@ -368,6 +409,10 @@ export const applyState = (partial: Partial<AlloyCalculatorState>) => {
       }
     }
 
+    if (partial.metalNuggets !== undefined) {
+      next.metalNuggets = { ...next.metalNuggets, ...partial.metalNuggets };
+    }
+
     return next;
   });
 };
@@ -376,10 +421,13 @@ export const alloyCalculation = derived(alloyCalculator, (state) => {
   const definition = getAlloyDefinition(state.selectedAlloy);
   if (!definition) {
     return {
+      mode: state.mode,
       alloyName: "",
-      parts: [],
+      parts: [] as Array<AlloyPartState & { units: number; nuggets: number; available: number; leftover: number }>,
       totalUnits: 0,
       totalPercent: 0,
+      producedIngots: 0,
+      remainderNuggets: 0,
       smeltTemp: formatTemperature(undefined),
       compatibleFuels: formatFuelList(undefined),
       barSegments: [{ label: "No metals", color: "#eee", flex: 1 }],
@@ -390,6 +438,85 @@ export const alloyCalculation = derived(alloyCalculator, (state) => {
   }
 
   const parts = buildPartsFromState(definition, state.metalPercentages);
+  const { totalPercent } = validateAlloyRatios(parts);
+
+  const compatibleFuels = definition.smeltTemp !== undefined
+    ? formatFuelList(getCompatibleFuels(definition.smeltTemp))
+    : formatFuelList(undefined);
+
+  const barSegments = totalPercent <= 0
+    ? [{ label: "No metals", color: "#eee", flex: 1 }]
+    : parts
+        .filter((part) => part.pct > 0)
+        .map((part) => ({
+          label: `${part.metal} ${part.pct.toFixed(1)}%`,
+          color: part.color || "#ccc",
+          flex: part.pct
+        }));
+
+  if (state.mode === "have") {
+    const splitResult = calculateAlloySplitFromNuggets(
+      state.metalNuggets,
+      parts.map((part) => ({
+        metal: part.metal,
+        color: part.color,
+        min: part.min,
+        max: part.max,
+        pct: part.pct
+      }))
+    );
+
+    const splitByMetal = new Map(
+      splitResult.parts.map((entry) => [entry.metal, entry])
+    );
+
+    const partsWithAllocations = parts.map((part) => {
+      const split = splitByMetal.get(part.metal);
+      return {
+        ...part,
+        units: split?.units ?? 0,
+        nuggets: split?.nuggets ?? 0,
+        available: split?.available ?? (state.metalNuggets[part.metal] ?? 0),
+        leftover: split?.leftover ?? (state.metalNuggets[part.metal] ?? 0)
+      };
+    });
+
+    const stackInputs = partsWithAllocations
+      .filter((part) => part.nuggets > 0)
+      .map((part) => ({
+        metal: part.metal,
+        color: part.color,
+        nuggets: part.nuggets
+      }));
+
+    return {
+      mode: state.mode,
+      alloyName: definition.name,
+      parts: partsWithAllocations,
+      totalUnits: splitResult.producedUnits,
+      totalPercent,
+      producedIngots: splitResult.producedIngots,
+      remainderNuggets: splitResult.totalNuggets % NUGGETS_PER_INGOT,
+      smeltTemp: formatTemperature(definition.smeltTemp),
+      compatibleFuels,
+      barSegments,
+      stackInputs,
+      stackPlan: stackInputs.length
+        ? computeAlloyStackPlan(
+          stackInputs,
+          parts.map((part) => ({
+            metal: part.metal,
+            color: part.color,
+            min: part.min,
+            max: part.max,
+            pct: part.pct
+          }))
+        )
+        : computeStackPlan([]),
+      hasStackInputs: stackInputs.length > 0
+    };
+  }
+
   const totalUnits = Math.max(0, state.targetIngots) * UNITS_PER_INGOT;
   const alloyAllocation = calculateAlloyAllocation(
     totalUnits,
@@ -408,24 +535,10 @@ export const alloyCalculation = derived(alloyCalculator, (state) => {
   const partsWithAllocations = parts.map((part) => ({
     ...part,
     units: allocationByMetal.get(part.metal)?.units ?? 0,
-    nuggets: allocationByMetal.get(part.metal)?.nuggets ?? 0
+    nuggets: allocationByMetal.get(part.metal)?.nuggets ?? 0,
+    available: 0,
+    leftover: 0
   }));
-
-  const { totalPercent } = validateAlloyRatios(parts);
-
-  const compatibleFuels = definition.smeltTemp !== undefined
-    ? formatFuelList(getCompatibleFuels(definition.smeltTemp))
-    : formatFuelList(undefined);
-
-  const barSegments = totalPercent <= 0
-    ? [{ label: "No metals", color: "#eee", flex: 1 }]
-    : parts
-        .filter((part) => part.pct > 0)
-        .map((part) => ({
-          label: `${part.metal} ${part.pct.toFixed(1)}%`,
-          color: part.color || "#ccc",
-          flex: part.pct
-        }));
 
   const stackInputs = partsWithAllocations
     .filter((part) => part.nuggets > 0)
@@ -436,10 +549,13 @@ export const alloyCalculation = derived(alloyCalculator, (state) => {
     }));
 
   return {
+    mode: state.mode,
     alloyName: definition.name,
     parts: partsWithAllocations,
     totalUnits,
     totalPercent,
+    producedIngots: 0,
+    remainderNuggets: 0,
     smeltTemp: formatTemperature(definition.smeltTemp),
     compatibleFuels,
     barSegments,

--- a/src/stores/metalCalculator.ts
+++ b/src/stores/metalCalculator.ts
@@ -1,6 +1,7 @@
 import { derived, writable } from "svelte/store";
 import metalDefinitionsRaw from "../data/metals.json";
 import {
+  NUGGETS_PER_INGOT,
   UNITS_PER_INGOT,
   formatTemperature,
   getMetalColor
@@ -8,11 +9,15 @@ import {
 import { computeIngotStackPlan } from "../lib/stack-plan";
 import { formatFuelList, getCompatibleFuels } from "../lib/fuels";
 import { calculatePureMetalAllocation } from "../lib/smelting";
-import type { Metal } from "../types/index";
+import type { CalculationMode, Metal } from "../types/index";
+
+const DEFAULT_NEED_VALUE = 10;
+const DEFAULT_HAVE_VALUE = 100;
 
 export type MetalCalculatorState = {
   selectedMetal: string;
-  targetIngots: number;
+  mode: CalculationMode;
+  inputValue: number;
 };
 
 const METAL_DEFINITIONS = metalDefinitionsRaw as Record<string, Metal>;
@@ -23,7 +28,8 @@ const initializeState = (): MetalCalculatorState => {
   const metalKeys = Object.keys(METAL_DEFINITIONS);
   return {
     selectedMetal: metalKeys[0] ?? "",
-    targetIngots: 10
+    mode: "need",
+    inputValue: DEFAULT_NEED_VALUE
   };
 };
 
@@ -38,11 +44,22 @@ export const setSelectedMetal = (metalKey: string) => {
   }));
 };
 
-export const setTargetIngots = (value: number | null) => {
-  const target = Math.max(0, Number(value) || 0);
+export const setMode = (mode: CalculationMode) => {
+  metalCalculator.update((state) => {
+    if (state.mode === mode) return state;
+    return {
+      ...state,
+      mode,
+      inputValue: mode === "need" ? DEFAULT_NEED_VALUE : DEFAULT_HAVE_VALUE
+    };
+  });
+};
+
+export const setInputValue = (value: number | null) => {
+  const safe = Math.max(0, Number(value) || 0);
   metalCalculator.update((state) => ({
     ...state,
-    targetIngots: target
+    inputValue: safe
   }));
 };
 
@@ -57,8 +74,12 @@ export const applyState = (partial: Partial<MetalCalculatorState>) => {
       }
     }
 
-    if (partial.targetIngots !== undefined) {
-      next.targetIngots = Math.max(0, Number(partial.targetIngots) || 0);
+    if (partial.mode !== undefined) {
+      next.mode = partial.mode;
+    }
+
+    if (partial.inputValue !== undefined) {
+      next.inputValue = Math.max(0, Number(partial.inputValue) || 0);
     }
 
     return next;
@@ -67,24 +88,51 @@ export const applyState = (partial: Partial<MetalCalculatorState>) => {
 
 export const metalCalculation = derived(metalCalculator, (state) => {
   const definition = getMetalDefinition(state.selectedMetal);
-  if (!definition) {
+  const emptyResult = {
+    mode: state.mode,
+    metalName: "",
+    metalColor: "#ccc",
+    smeltTemp: formatTemperature(undefined),
+    compatibleFuels: formatFuelList(undefined),
+    oreSources: "-",
+    nuggetsNeeded: 0,
+    producedIngots: 0,
+    remainderNuggets: 0,
+    hasStackInputs: false,
+    stackPlan: computeIngotStackPlan([])
+  };
+
+  if (!definition) return emptyResult;
+
+  const metalColor = definition.color || getMetalColor(state.selectedMetal || definition.name);
+  const compatibleFuels = formatFuelList(getCompatibleFuels(definition.smeltTemp));
+
+  if (state.mode === "have") {
+    const available = Math.max(0, Math.floor(state.inputValue));
+    const producedIngots = Math.floor(available / NUGGETS_PER_INGOT);
+    const remainderNuggets = available % NUGGETS_PER_INGOT;
+    const stackInputs = available > 0
+      ? [{ metal: definition.name, color: metalColor, nuggets: available }]
+      : [];
+
     return {
-      metalName: "",
-      metalColor: "#ccc",
-      smeltTemp: formatTemperature(undefined),
-      compatibleFuels: formatFuelList(undefined),
-      oreSources: "-",
+      mode: state.mode,
+      metalName: definition.name,
+      metalColor,
+      smeltTemp: formatTemperature(definition.smeltTemp),
+      compatibleFuels,
+      oreSources: definition.ores.join(", "),
       nuggetsNeeded: 0,
-      hasStackInputs: false,
-      stackPlan: computeIngotStackPlan([])
+      producedIngots,
+      remainderNuggets,
+      hasStackInputs: stackInputs.length > 0,
+      stackPlan: computeIngotStackPlan(stackInputs)
     };
   }
 
-  const metalColor = definition.color || getMetalColor(state.selectedMetal || definition.name);
-  const requiredUnits = Math.max(0, state.targetIngots) * UNITS_PER_INGOT;
+  const requiredUnits = Math.max(0, state.inputValue) * UNITS_PER_INGOT;
   const casting = calculatePureMetalAllocation(requiredUnits, definition.name, metalColor);
   const nuggetsNeeded = casting.requiredNuggets;
-  const compatibleFuels = formatFuelList(getCompatibleFuels(definition.smeltTemp));
   const stackInputs = nuggetsNeeded
     ? casting.metals.map((entry) => ({
       metal: entry.metal,
@@ -94,12 +142,15 @@ export const metalCalculation = derived(metalCalculator, (state) => {
     : [];
 
   return {
+    mode: state.mode,
     metalName: definition.name,
     metalColor,
     smeltTemp: formatTemperature(definition.smeltTemp),
     compatibleFuels,
     oreSources: definition.ores.join(", "),
     nuggetsNeeded,
+    producedIngots: 0,
+    remainderNuggets: 0,
     hasStackInputs: stackInputs.length > 0,
     stackPlan: computeIngotStackPlan(stackInputs)
   };

--- a/src/stores/share/alloyCodec.ts
+++ b/src/stores/share/alloyCodec.ts
@@ -13,13 +13,20 @@ const ALLOY_DEFINITIONS = alloyDefinitionsRaw as Record<string, Alloy>;
 
 const getAlloyDefinition = (key: string) => ALLOY_DEFINITIONS[key];
 
+const NUGGET_PARAM_PREFIX = "h_";
+
 export function registerAlloyShareCodec(): void {
   registerShareCodec("alloying", {
     encode() {
       const state = get(alloyCalculator);
       const params = new URLSearchParams();
       params.set("a", state.selectedAlloy);
-      params.set("n", String(state.targetIngots));
+
+      if (state.mode === "have") {
+        params.set("d", "h");
+      } else {
+        params.set("n", String(state.targetIngots));
+      }
 
       const definition = getAlloyDefinition(state.selectedAlloy);
       if (definition) {
@@ -27,6 +34,12 @@ export function registerAlloyShareCodec(): void {
           const pct = state.metalPercentages[part.metal];
           if (pct !== undefined) {
             params.set(part.metal, pct.toFixed(ALLOY_PERCENT_PRECISION));
+          }
+          if (state.mode === "have") {
+            const nuggets = state.metalNuggets[part.metal];
+            if (nuggets !== undefined) {
+              params.set(`${NUGGET_PARAM_PREFIX}${part.metal}`, String(nuggets));
+            }
           }
         }
       }
@@ -41,11 +54,17 @@ export function registerAlloyShareCodec(): void {
         partial.selectedAlloy = alloyKey;
       }
 
-      const ingots = params.get("n");
-      if (ingots !== null) {
-        const n = Number(ingots);
-        if (Number.isFinite(n) && n >= 0) {
-          partial.targetIngots = n;
+      const direction = params.get("d");
+      if (direction === "h") {
+        partial.mode = "have";
+      } else {
+        partial.mode = "need";
+        const ingots = params.get("n");
+        if (ingots !== null) {
+          const n = Number(ingots);
+          if (Number.isFinite(n) && n >= 0) {
+            partial.targetIngots = n;
+          }
         }
       }
 
@@ -53,7 +72,9 @@ export function registerAlloyShareCodec(): void {
       const definition = getAlloyDefinition(targetAlloy);
       if (definition) {
         const percentages: Record<string, number> = {};
-        let hasAny = false;
+        const nuggets: Record<string, number> = {};
+        let hasPercentages = false;
+        let hasNuggets = false;
 
         for (const part of definition.parts) {
           const val = params.get(part.metal);
@@ -61,13 +82,25 @@ export function registerAlloyShareCodec(): void {
             const pct = Number(val);
             if (Number.isFinite(pct)) {
               percentages[part.metal] = pct;
-              hasAny = true;
+              hasPercentages = true;
+            }
+          }
+
+          const nuggetVal = params.get(`${NUGGET_PARAM_PREFIX}${part.metal}`);
+          if (nuggetVal !== null) {
+            const n = Number(nuggetVal);
+            if (Number.isFinite(n) && n >= 0) {
+              nuggets[part.metal] = n;
+              hasNuggets = true;
             }
           }
         }
 
-        if (hasAny) {
+        if (hasPercentages) {
           partial.metalPercentages = percentages;
+        }
+        if (hasNuggets) {
+          partial.metalNuggets = nuggets;
         }
       }
 

--- a/src/stores/share/index.ts
+++ b/src/stores/share/index.ts
@@ -1,5 +1,6 @@
 import { registerAlloyShareCodec } from "./alloyCodec";
 import { registerMetalShareCodec } from "./metalCodec";
+import { registerUsageShareCodec } from "./usageCodec";
 
 let initialized = false;
 
@@ -7,5 +8,6 @@ export function setupShareCodecs(): void {
   if (initialized) return;
   registerAlloyShareCodec();
   registerMetalShareCodec();
+  registerUsageShareCodec();
   initialized = true;
 }

--- a/src/stores/share/metalCodec.ts
+++ b/src/stores/share/metalCodec.ts
@@ -18,7 +18,10 @@ export function registerMetalShareCodec(): void {
       const state = get(metalCalculator);
       const params = new URLSearchParams();
       params.set("m", state.selectedMetal);
-      params.set("n", String(state.targetIngots));
+      params.set("n", String(state.inputValue));
+      if (state.mode === "have") {
+        params.set("d", "h");
+      }
       return params;
     },
     apply(params) {
@@ -29,11 +32,18 @@ export function registerMetalShareCodec(): void {
         partial.selectedMetal = metalKey;
       }
 
-      const ingots = params.get("n");
-      if (ingots !== null) {
-        const n = Number(ingots);
-        if (Number.isFinite(n) && n >= 0) {
-          partial.targetIngots = n;
+      const direction = params.get("d");
+      if (direction === "h") {
+        partial.mode = "have";
+      } else {
+        partial.mode = "need";
+      }
+
+      const n = params.get("n");
+      if (n !== null) {
+        const value = Number(n);
+        if (Number.isFinite(value) && value >= 0) {
+          partial.inputValue = value;
         }
       }
 

--- a/src/stores/share/usageCodec.ts
+++ b/src/stores/share/usageCodec.ts
@@ -1,0 +1,36 @@
+import { get } from "svelte/store";
+import metalDefinitionsRaw from "../../data/metals.json";
+import { registerShareCodec } from "../../lib/url-state";
+import {
+  applyState,
+  usageFinder,
+  type InventoryEntry
+} from "../usageFinder";
+import type { Metal } from "../../types";
+
+const METAL_DEFINITIONS = metalDefinitionsRaw as Record<string, Metal>;
+
+export function registerUsageShareCodec(): void {
+  registerShareCodec("usage", {
+    encode() {
+      const state = get(usageFinder);
+      const params = new URLSearchParams();
+      for (const entry of state.inventory) {
+        params.set(entry.metalKey, String(entry.nuggets));
+      }
+      return params;
+    },
+    apply(params) {
+      const inventory: InventoryEntry[] = [];
+      for (const [key, value] of params.entries()) {
+        if (!METAL_DEFINITIONS[key]) continue;
+        const nuggets = Number(value);
+        if (!Number.isFinite(nuggets) || nuggets < 0) continue;
+        inventory.push({ metalKey: key, nuggets });
+      }
+      if (inventory.length) {
+        applyState({ inventory });
+      }
+    }
+  });
+}

--- a/src/stores/usageFinder.ts
+++ b/src/stores/usageFinder.ts
@@ -1,0 +1,222 @@
+import { derived, writable } from "svelte/store";
+import alloyDefinitionsRaw from "../data/alloys.json";
+import metalDefinitionsRaw from "../data/metals.json";
+import {
+  NUGGETS_PER_INGOT,
+  formatTemperature,
+  getMetalColor
+} from "../lib/constants";
+import { calculateAlloySplitFromNuggets } from "../lib/smelting";
+import { computeAlloyStackPlan, computeIngotStackPlan } from "../lib/stack-plan";
+import { formatFuelList, getCompatibleFuels } from "../lib/fuels";
+import type { Alloy, Calculation, Metal } from "../types/index";
+
+const ALLOY_DEFINITIONS = alloyDefinitionsRaw as Record<string, Alloy>;
+const METAL_DEFINITIONS = metalDefinitionsRaw as Record<string, Metal>;
+const DEFAULT_NUGGETS = 100;
+
+export type InventoryEntry = {
+  metalKey: string;
+  nuggets: number;
+};
+
+export type UsageFinderState = {
+  inventory: InventoryEntry[];
+  expandedResults: Set<string>;
+};
+
+export type UsageResult = {
+  key: string;
+  type: "pure" | "alloy";
+  name: string;
+  ingots: number;
+  leftoverNuggets: number;
+  smeltTemp: string;
+  compatibleFuels: string;
+  stackPlan: Calculation;
+  hasStackInputs: boolean;
+  details: UsageResultDetail[];
+};
+
+export type UsageResultDetail = {
+  metal: string;
+  available: number;
+  used: number;
+  leftover: number;
+};
+
+const initializeState = (): UsageFinderState => ({
+  inventory: [],
+  expandedResults: new Set()
+});
+
+export const usageFinder = writable<UsageFinderState>(initializeState());
+
+/** All metal keys available for selection (both pure and alloy components). */
+export const allMetalKeys = Object.keys(METAL_DEFINITIONS);
+
+export const getMetalName = (key: string): string =>
+  METAL_DEFINITIONS[key]?.name ?? key;
+
+export const addMetal = (metalKey: string) => {
+  usageFinder.update((state) => {
+    if (state.inventory.some((e) => e.metalKey === metalKey)) return state;
+    return {
+      ...state,
+      inventory: [...state.inventory, { metalKey, nuggets: DEFAULT_NUGGETS }]
+    };
+  });
+};
+
+export const removeMetal = (metalKey: string) => {
+  usageFinder.update((state) => ({
+    ...state,
+    inventory: state.inventory.filter((e) => e.metalKey !== metalKey)
+  }));
+};
+
+export const setNuggets = (metalKey: string, value: number) => {
+  const safe = Math.max(0, Number(value) || 0);
+  usageFinder.update((state) => ({
+    ...state,
+    inventory: state.inventory.map((e) =>
+      e.metalKey === metalKey ? { ...e, nuggets: safe } : e
+    )
+  }));
+};
+
+export const toggleExpanded = (resultKey: string) => {
+  usageFinder.update((state) => {
+    const next = new Set(state.expandedResults);
+    if (next.has(resultKey)) {
+      next.delete(resultKey);
+    } else {
+      next.add(resultKey);
+    }
+    return { ...state, expandedResults: next };
+  });
+};
+
+export const applyState = (partial: { inventory?: InventoryEntry[] }) => {
+  usageFinder.update((state) => {
+    const next = { ...state };
+    if (partial.inventory) {
+      next.inventory = partial.inventory;
+    }
+    return next;
+  });
+};
+
+export const usageFinderResults = derived(usageFinder, (state): UsageResult[] => {
+  if (!state.inventory.length) return [];
+
+  const inventoryMap = new Map<string, number>();
+  for (const entry of state.inventory) {
+    inventoryMap.set(entry.metalKey, entry.nuggets);
+  }
+
+  // Map metal names (capitalized) → nuggets for alloy matching
+  const nuggetsByName = new Map<string, number>();
+  for (const entry of state.inventory) {
+    const def = METAL_DEFINITIONS[entry.metalKey];
+    if (def) {
+      nuggetsByName.set(def.name, entry.nuggets);
+    }
+  }
+
+  const results: UsageResult[] = [];
+
+  // Pure cast options
+  for (const entry of state.inventory) {
+    if (entry.nuggets < NUGGETS_PER_INGOT) continue;
+    const def = METAL_DEFINITIONS[entry.metalKey];
+    if (!def) continue;
+
+    const ingots = Math.floor(entry.nuggets / NUGGETS_PER_INGOT);
+    const leftover = entry.nuggets % NUGGETS_PER_INGOT;
+    const color = def.color || getMetalColor(entry.metalKey);
+    const stackInputs = [{ metal: def.name, color, nuggets: entry.nuggets }];
+
+    results.push({
+      key: `pure_${entry.metalKey}`,
+      type: "pure",
+      name: `${def.name} (pure)`,
+      ingots,
+      leftoverNuggets: leftover,
+      smeltTemp: formatTemperature(def.smeltTemp),
+      compatibleFuels: formatFuelList(getCompatibleFuels(def.smeltTemp)),
+      stackPlan: computeIngotStackPlan(stackInputs),
+      hasStackInputs: true,
+      details: [
+        {
+          metal: def.name,
+          available: entry.nuggets,
+          used: ingots * NUGGETS_PER_INGOT,
+          leftover
+        }
+      ]
+    });
+  }
+
+  // Alloy options
+  for (const [alloyKey, alloy] of Object.entries(ALLOY_DEFINITIONS)) {
+    // Check all required metals are in inventory
+    const allPresent = alloy.parts.every((part) => nuggetsByName.has(part.metal));
+    if (!allPresent) continue;
+
+    const availableNuggets: Record<string, number> = {};
+    for (const part of alloy.parts) {
+      availableNuggets[part.metal] = nuggetsByName.get(part.metal) ?? 0;
+    }
+
+    // Calculate using midpoint percentages
+    const constraints = alloy.parts.map((part) => ({
+      metal: part.metal,
+      color: part.color || getMetalColor(part.metal),
+      min: part.min,
+      max: part.max,
+      pct: (part.min + part.max) / 2
+    }));
+
+    const split = calculateAlloySplitFromNuggets(availableNuggets, constraints);
+    if (split.producedIngots <= 0) continue;
+
+    const stackInputs = split.parts
+      .filter((p) => p.nuggets > 0)
+      .map((p) => ({
+        metal: p.metal,
+        color: p.color,
+        nuggets: p.nuggets
+      }));
+
+    const totalLeftover = split.parts.reduce((sum, p) => sum + p.leftover, 0);
+
+    results.push({
+      key: `alloy_${alloyKey}`,
+      type: "alloy",
+      name: alloy.name,
+      ingots: split.producedIngots,
+      leftoverNuggets: totalLeftover,
+      smeltTemp: formatTemperature(alloy.smeltTemp),
+      compatibleFuels: alloy.smeltTemp !== undefined
+        ? formatFuelList(getCompatibleFuels(alloy.smeltTemp))
+        : formatFuelList(undefined),
+      stackPlan: computeAlloyStackPlan(stackInputs, constraints),
+      hasStackInputs: stackInputs.length > 0,
+      details: split.parts.map((p) => ({
+        metal: p.metal,
+        available: p.available,
+        used: p.nuggets,
+        leftover: p.leftover
+      }))
+    });
+  }
+
+  // Sort: alloys first (by ingots desc), then pure (by ingots desc)
+  results.sort((a, b) => {
+    if (a.type !== b.type) return a.type === "alloy" ? -1 : 1;
+    return b.ingots - a.ingots;
+  });
+
+  return results;
+});

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,3 +1,5 @@
+export type CalculationMode = "need" | "have";
+
 export interface AlloyPart {
   metal: string;
   min: number;

--- a/styles/calculator/layout.css
+++ b/styles/calculator/layout.css
@@ -125,6 +125,17 @@
   overflow-x: hidden;
 }
 
+/* 6-column grid for "have" mode with Available / Used / Leftover columns */
+#calculator.calc-six-cols {
+  --calc-grid: minmax(130px, 1.2fr) minmax(110px, 1fr) minmax(90px, 0.8fr) minmax(80px, 0.75fr) minmax(90px, 0.8fr) minmax(190px, 1.3fr);
+}
+
+#calculator.calc-six-cols th:nth-child(3),
+#calculator.calc-six-cols th:nth-child(4),
+#calculator.calc-six-cols th:nth-child(5) {
+  text-align: right;
+}
+
 .calculator-main {
   width: 100%;
   margin-bottom: 0;

--- a/styles/calculator/responsive.css
+++ b/styles/calculator/responsive.css
@@ -21,6 +21,10 @@
     --calc-grid: minmax(130px, 1.2fr) minmax(120px, 1fr) minmax(110px, 0.95fr) minmax(110px, 0.95fr) minmax(190px, 1.3fr);
   }
 
+  #calculator.calc-six-cols {
+    --calc-grid: minmax(110px, 1.1fr) minmax(100px, 0.95fr) minmax(80px, 0.75fr) minmax(70px, 0.7fr) minmax(80px, 0.75fr) minmax(160px, 1.1fr);
+  }
+
   #calculator table {
     font-size: 0.9rem;
     border-spacing: 0 8px;
@@ -47,6 +51,10 @@
     padding: var(--spacing-sm);
     /* Narrower grid while keeping readability; horizontal scroll remains available */
     --calc-grid: minmax(115px, 1fr) minmax(100px, 0.9fr) minmax(95px, 0.85fr) minmax(95px, 0.85fr) minmax(170px, 1.2fr);
+  }
+
+  #calculator.calc-six-cols {
+    --calc-grid: minmax(100px, 1fr) minmax(90px, 0.85fr) minmax(75px, 0.7fr) minmax(65px, 0.65fr) minmax(75px, 0.7fr) minmax(140px, 1fr);
   }
   #calculator table { font-size: 0.85rem; }
 }

--- a/styles/components.css
+++ b/styles/components.css
@@ -528,3 +528,205 @@
     grid-template-columns: 1fr;
   }
 }
+
+/* ── Mode Toggle (Segmented Control) ──────────────────────────── */
+
+.mode-toggle {
+  display: flex;
+  background: var(--surface-muted);
+  border: 1px solid var(--border-soft);
+  border-radius: var(--border-radius);
+  padding: 3px;
+  gap: 2px;
+}
+
+.mode-toggle button {
+  flex: 1;
+  padding: 8px 12px;
+  border: none;
+  border-radius: calc(var(--border-radius) - 2px);
+  background: transparent;
+  color: var(--text-secondary);
+  font: inherit;
+  font-size: 0.85rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all var(--transition);
+  white-space: nowrap;
+}
+
+.mode-toggle button:hover:not(.active) {
+  color: var(--text-primary);
+  background: var(--surface-hover);
+}
+
+.mode-toggle button.active {
+  background: var(--primary-color);
+  color: white;
+  box-shadow: 0 1px 3px var(--shadow);
+}
+
+.mode-toggle button:focus-visible {
+  outline: 2px solid var(--primary-color);
+  outline-offset: -2px;
+}
+
+/* Usage Finder */
+.usage-results {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-md);
+}
+
+.usage-empty {
+  text-align: center;
+  padding: var(--spacing-xl) var(--spacing-lg);
+  color: var(--text-secondary);
+  font-size: 1rem;
+}
+
+.inventory-row {
+  display: flex;
+  align-items: flex-end;
+  gap: var(--spacing-sm);
+}
+
+.inventory-input {
+  flex: 1;
+  min-width: 0;
+}
+
+.inventory-remove {
+  flex-shrink: 0;
+  width: 40px;
+  height: 40px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: 2px solid var(--border-soft);
+  border-radius: calc(var(--border-radius) / 2);
+  background: var(--surface-raised);
+  color: var(--text-secondary);
+  font-size: 1.2rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  margin-bottom: 4px;
+}
+
+.inventory-remove:hover {
+  border-color: #c53030;
+  color: #c53030;
+  background: rgba(197, 48, 48, 0.08);
+}
+
+.inventory-remove:focus-visible {
+  outline: 2px solid var(--primary-color);
+  outline-offset: -2px;
+}
+
+.result-card {
+  display: block;
+  width: 100%;
+  text-align: left;
+  background: var(--surface-raised);
+  border: 1px solid var(--border-soft);
+  border-radius: var(--border-radius);
+  padding: 0;
+  cursor: pointer;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+  font: inherit;
+  color: inherit;
+}
+
+.result-card:hover {
+  border-color: var(--primary-color);
+  box-shadow: 0 4px 12px var(--shadow-hover);
+}
+
+.result-card:focus-visible {
+  outline: 2px solid var(--primary-color);
+  outline-offset: -2px;
+}
+
+.result-header {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+  padding: var(--spacing-md) var(--spacing-lg);
+  flex-wrap: wrap;
+}
+
+.result-name {
+  font-weight: 600;
+  font-size: 1rem;
+  color: var(--text-primary);
+}
+
+.result-badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 2px 10px;
+  border-radius: 999px;
+  background: var(--primary-color);
+  color: #fff;
+  font-size: 0.8rem;
+  font-weight: 600;
+  white-space: nowrap;
+}
+
+.result-summary {
+  color: var(--text-secondary);
+  font-size: 0.88rem;
+  flex: 1;
+}
+
+.result-chevron {
+  color: var(--text-secondary);
+  font-size: 0.9rem;
+  flex-shrink: 0;
+}
+
+.result-details {
+  padding: 0 var(--spacing-lg) var(--spacing-lg);
+  border-top: 1px solid var(--border-soft);
+  cursor: default;
+}
+
+.result-breakdown {
+  width: 100%;
+  border-collapse: collapse;
+  margin: var(--spacing-md) 0;
+  font-size: 0.9rem;
+}
+
+.result-breakdown th {
+  text-align: left;
+  font-weight: 600;
+  color: var(--text-secondary);
+  text-transform: uppercase;
+  font-size: 0.78rem;
+  letter-spacing: 0.05em;
+  padding: 8px 12px;
+  border-bottom: 2px solid var(--border-soft);
+}
+
+.result-breakdown td {
+  padding: 8px 12px;
+  border-bottom: 1px solid var(--border-soft);
+  color: var(--text-primary);
+}
+
+.result-breakdown th:not(:first-child),
+.result-breakdown td:not(:first-child) {
+  text-align: right;
+}
+
+.result-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--spacing-sm) var(--spacing-lg);
+  color: var(--text-secondary);
+  font-size: 0.88rem;
+  margin-bottom: var(--spacing-md);
+}


### PR DESCRIPTION
- Implemented UsageFinder.svelte to allow users to input available metals and see potential crafts.
- Integrated inventory management for metals with add, remove, and nugget input functionalities.
- Added support for sharing usage state via URL encoding.
- Enhanced alloy and metal calculators to support new "have" mode for inputting available nuggets.
- Updated share codecs for alloy and metal calculators to handle new modes and input values.
- Introduced responsive styles for the new Usage Finder layout and controls.
- Added segmented control for toggling between "need" and "have" modes in calculators.