### PR TITLE
feat: add Charcoal Calculator for pit planning and charcoal yield estimation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,15 +8,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added Charcoal Calculator tool (`#charcoal`) for pit planning, firewood resource estimation, and charcoal yield calculations
+- Added interactive 3D isometric pit preview component that visualizes charcoal pit dimensions
+- Added charcoal calculator store with bidirectional calculation support ("I have a pit" and "I need charcoal" modes) and clamped dimension inputs
+- Added configurable button labels (`needLabel`, `haveLabel`) to `mode-toggle.svelte` so each calculator can use context-specific wording
+- Added charcoal share codec supporting shareable URLs for saved pit configurations (e.g., `#charcoal?d=h&w=5&dp=5&h=5`)
+- Added burn time calculations in both game hours and real-world minutes (configurable via charcoal data constants)
+- Added charcoal data definitions module (`src/data/charcoal.json`) with pit limits, firewood-to-charcoal ratios, and burn-time constants
+
+### Changed
+
+- Updated home page to feature the new Charcoal Calculator alongside other tools
+- Updated app navigation to include Charcoal Calculator route and home page tool cards
+
 ## [0.6.1] - 2026-04-14
-
-### Fixed
-
-- Fixed compatible fuels display for alloys now using the highest ingredient melting temperature instead of the alloy's own temperature (e.g. Cupronickel now correctly requires Coke to melt the Nickel at 1325°C)
 
 ### Added
 
 - Added per-ingredient smelting breakdown in the Alloying Calculator and Usage Finder, showing each metal's individual melting temperature and compatible fuels
+
+### Fixed
+
+- Fixed compatible fuels display for alloys now using the highest ingredient melting temperature instead of the alloy's own temperature (e.g. Cupronickel now correctly requires Coke to melt the Nickel at 1325°C)
 
 ## [0.6.0] - 2026-04-14
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,10 @@ Calculate the number of ore nuggets needed to cast metal ingots in a crucible. S
 
 Enter the metals you have and discover every alloy and casting option available to you. The tool checks your inventory against all game recipes, shows how many ingots each option yields, and provides a per-metal breakdown of nuggets used versus leftover. Expanding a result reveals the full stack plan and compatible fuels.
 
+### Charcoal Calculator
+
+Calculate pit dimensions, firewood requirements, and charcoal yield for your smelting operations. Supports both "I have a pit" mode (calculate resources needed) and "I need charcoal" mode (find suggested pit size). Includes burn time calculations in both game and real-world minutes, an interactive 3D pit preview, and support for shareable calculator URLs.
+
 ## Shareable Recipe URLs
 
 Both calculators support URL-encoded state so you can share exact setups with others.
@@ -83,69 +87,75 @@ Send feedback from a dedicated in-app page without creating an account. Submissi
 ## Project Structure
 
 ```shell
-VintageStoryCalculator/         # Root directory
-├── .github/                    # Issue templates and repo automation
-├── index.html                  # Vite entry point
-├── package.json                # Project configuration and scripts
-├── src/                        # Svelte application source
-│   ├── App.svelte              # Root layout and navigation
-│   ├── components/             # Reusable UI components
+VintageStoryCalculator/             # Root directory
+├── .github/                        # Issue templates and repo automation
+├── index.html                      # Vite entry point
+├── package.json                    # Project configuration and scripts
+├── src/                            # Svelte application source
+│   ├── App.svelte                  # Root layout and navigation
+│   ├── components/                 # Reusable UI components
 │   │   ├── calculator-card.svelte
 │   │   ├── feedback-form.svelte
 │   │   ├── mode-toggle.svelte
 │   │   ├── number-input.svelte
+│   │   ├── pit-preview.svelte
 │   │   ├── result-display.svelte
 │   │   ├── select-input.svelte
 │   │   ├── share-button.svelte
 │   │   ├── settings-modal.svelte
 │   │   ├── stack-plan-panel.svelte
 │   │   └── temperature-display.svelte
-│   ├── data/                   # Game data files
-│   │   ├── alloys.json         # Alloy recipes and definitions
-│   │   ├── constants.json      # Shared game constants and fuel data
-│   │   ├── fuels.json          # Fuel definitions and burn times
-│   │   └── metals.json         # Metal definitions
-│   ├── lib/                    # Shared utilities
-│   │   ├── calculations.ts     # Pure calculator helpers
-│   │   ├── constants.ts        # Typed constants exports
-│   │   ├── fuels.ts            # Typed fuel definitions
-│   │   ├── numberFormatting.ts # Shared numeric formatting helpers
-│   │   ├── stack-display.ts    # Process and stack display labels
-│   │   ├── stack-plan.ts       # Stack breakdown helper
-│   │   ├── url-state.ts        # Share URL codec registry and parsing helpers
-│   │   ├── smelting/           # Smelting planning and allocation helpers
+│   ├── data/                       # Game data files
+│   │   ├── alloys.json             # Alloy recipes and definitions
+│   │   ├── charcoal.json           # Charcoal pit constants and yield data
+│   │   ├── constants.json          # Shared game constants and fuel data
+│   │   ├── fuels.json              # Fuel definitions and burn times
+│   │   └── metals.json             # Metal definitions
+│   ├── lib/                        # Shared utilities
+│   │   ├── calculations.ts         # Pure calculator helpers
+│   │   ├── charcoal.ts             # Charcoal calculation and pit planning helpers
+│   │   ├── constants.ts            # Typed constants exports
+│   │   ├── fuels.ts                # Typed fuel definitions
+│   │   ├── numberFormatting.ts     # Shared numeric formatting helpers
+│   │   ├── stack-display.ts        # Process and stack display labels
+│   │   ├── stack-plan.ts           # Stack breakdown helper
+│   │   ├── url-state.ts            # Share URL codec registry and parsing helpers
+│   │   ├── smelting/               # Smelting planning and allocation helpers
 │   │   │   ├── allocation.ts
 │   │   │   ├── index.ts
 │   │   │   ├── planner.ts
 │   │   │   └── types.ts
-│   │   └── version.ts          # Changelog parser
-│   ├── main.ts                 # Application bootstrap
-│   ├── stores/                 # Svelte stores
-│   │   ├── alloyCalculator.ts  # Alloying calculator store
-│   │   ├── metalCalculator.ts  # Casting calculator store
-│   │   ├── settings.ts         # Persistent UI settings store
-│   │   ├── usageFinder.ts      # Usage Finder inventory and results store
-│   │   ├── share/              # URL sharing codecs per calculator
+│   │   └── version.ts              # Changelog parser
+│   ├── main.ts                     # Application bootstrap
+│   ├── stores/                     # Svelte stores
+│   │   ├── alloyCalculator.ts      # Alloying calculator store
+│   │   ├── charcoalCalculator.ts   # Charcoal calculator store
+│   │   ├── metalCalculator.ts      # Casting calculator store
+│   │   ├── settings.ts             # Persistent UI settings store
+│   │   ├── usageFinder.ts          # Usage Finder inventory and results store
+│   │   ├── share/                  # URL sharing codecs per calculator
 │   │   │   ├── alloyCodec.ts
+│   │   │   ├── charcoalCodec.ts
 │   │   │   ├── index.ts
 │   │   │   ├── metalCodec.ts
 │   │   │   └── usageCodec.ts
-│   │   └── theme.ts            # Theme store
-│   ├── types/                  # Shared TypeScript interfaces
-│   │   ├── components.ts       # Component prop and event contracts
-│   │   └── index.ts            # Data and calculation types
-│   └── routes/                 # Route-aligned components
+│   │   └── theme.ts                # Theme store
+│   ├── types/                      # Shared TypeScript interfaces
+│   │   ├── components.ts           # Component prop and event contracts
+│   │   └── index.ts                # Data and calculation types
+│   └── routes/                     # Route-aligned components
 │       ├── AlloyingCalculator.svelte
 │       ├── CastingCalculator.svelte
+│       ├── CharcoalCalculator.svelte
 │       ├── Feedback.svelte
 │       ├── Home.svelte
 │       ├── Privacy.svelte
 │       └── UsageFinder.svelte
-├── tsconfig.json               # TypeScript configuration
-├── .eslintrc.cjs               # ESLint configuration
-├── styles/                     # Shared styling
+├── tsconfig.json                   # TypeScript configuration
+├── .eslintrc.cjs                   # ESLint configuration
+├── styles/                         # Shared styling
 │   ├── base.css
-│   ├── calculator.css          # Calculator style entrypoint importing modular partials
+│   ├── calculator.css              # Calculator style entrypoint importing modular partials
 │   ├── calculator/
 │   │   ├── layout.css
 │   │   ├── responsive.css
@@ -154,9 +164,9 @@ VintageStoryCalculator/         # Root directory
 │   ├── components.css
 │   ├── layout.css
 │   └── themes.css
-├── CHANGELOG.md                # Release notes
-├── LICENSE                     # MIT License
-└── README.md                   # Project overview
+├── CHANGELOG.md                    # Release notes
+├── LICENSE                         # MIT License
+└── README.md                       # Project overview
 ```
 
 ## Browser Support

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -4,6 +4,7 @@
   import Home from "./routes/Home.svelte";
   import AlloyingCalculator from "./routes/AlloyingCalculator.svelte";
   import CastingCalculator from "./routes/CastingCalculator.svelte";
+  import CharcoalCalculator from "./routes/CharcoalCalculator.svelte";
   import UsageFinder from "./routes/UsageFinder.svelte";
   import Feedback from "./routes/Feedback.svelte";
   import Privacy from "./routes/Privacy.svelte";
@@ -22,13 +23,14 @@
     { id: "home", label: "Home", hash: "#home" },
     { id: "alloying", label: "Alloying Calculator", hash: "#alloying" },
     { id: "casting", label: "Casting Calculator", hash: "#casting" },
+    { id: "charcoal", label: "Charcoal Calculator", hash: "#charcoal" },
     { id: "usage", label: "Usage Finder", hash: "#usage" },
     { id: "feedback", label: "Feedback", hash: "#feedback" },
     { id: "privacy", label: "Privacy", hash: "#privacy" }
   ] as const;
 
   const CALCULATOR_NAV_ITEMS = NAV_ITEMS.filter(
-    (item) => item.id === "alloying" || item.id === "casting" || item.id === "usage"
+    (item) => item.id === "alloying" || item.id === "casting" || item.id === "charcoal" || item.id === "usage"
   );
 
   type RouteId = (typeof NAV_ITEMS)[number]["id"];
@@ -39,6 +41,7 @@
     home: Home,
     alloying: AlloyingCalculator,
     casting: CastingCalculator,
+    charcoal: CharcoalCalculator,
     usage: UsageFinder,
     feedback: Feedback,
     privacy: Privacy
@@ -53,6 +56,7 @@
     const route = parseRouteFromHash(hash);
     if (route === "alloying") return "alloying";
     if (route === "casting") return "casting";
+    if (route === "charcoal") return "charcoal";
     if (route === "usage") return "usage";
     if (route === "feedback") return "feedback";
     if (route === "privacy") return "privacy";
@@ -82,6 +86,7 @@
       home: `${baseTitle} — Home`,
       alloying: `${baseTitle} — Alloying Calculator`,
       casting: `${baseTitle} — Casting Calculator`,
+      charcoal: `${baseTitle} — Charcoal Calculator`,
       usage: `${baseTitle} — Usage Finder`,
       feedback: `${baseTitle} — Feedback`,
       privacy: `${baseTitle} — Privacy`
@@ -93,6 +98,8 @@
         "Calculate exact metal ratios and nuggets for Vintage Story alloys like Tin Bronze, Bismuth Bronze, Electrum, and more.",
       casting:
         "Calculate ore nuggets needed to cast metal ingots in Vintage Story. Supports all castable metals including Copper, Gold, Silver, and more.",
+      charcoal:
+        "Plan charcoal pit dimensions, calculate firewood and logs needed, and estimate charcoal yield for Vintage Story.",
       usage:
         "Enter the metals you have and discover every alloy and casting option available to you in Vintage Story.",
       feedback:

--- a/src/components/mode-toggle.svelte
+++ b/src/components/mode-toggle.svelte
@@ -3,6 +3,8 @@
   import type { CalculationMode } from "../types/index";
 
   export let mode: CalculationMode = "need";
+  export let needLabel: string = "I need ingots";
+  export let haveLabel: string = "I have nuggets";
 
   const dispatch = createEventDispatcher<{ change: { value: CalculationMode } }>();
 
@@ -20,7 +22,7 @@
     class:active={mode === "need"}
     on:click={() => handleClick("need")}
   >
-    I need ingots
+    {needLabel}
   </button>
   <button
     type="button"
@@ -29,6 +31,6 @@
     class:active={mode === "have"}
     on:click={() => handleClick("have")}
   >
-    I have nuggets
+    {haveLabel}
   </button>
 </div>

--- a/src/components/pit-preview.svelte
+++ b/src/components/pit-preview.svelte
@@ -1,0 +1,178 @@
+<script lang="ts">
+  export let width: number = 3;
+  export let depth: number = 3;
+  export let height: number = 3;
+
+  // Isometric projection constants
+  const COS30 = Math.cos(Math.PI / 6);  // ≈ 0.866
+  const SIN30 = 0.5;
+
+  // Scale cell so the graphic fits a reasonable bounding box
+  $: maxDim = Math.max(width, depth, height, 1);
+  $: cell = Math.max(4, Math.min(24, 140 / maxDim));
+
+  // Convert grid (x, y, z) → screen (sx, sy), origin at top-center
+  function isoX(x: number, y: number): number {
+    return (x - y) * cell * COS30;
+  }
+  function isoY(x: number, y: number, z: number): number {
+    return (x + y) * cell * SIN30 - z * cell;
+  }
+
+  // Build cube face polygons for one block at grid position (gx, gy, gz)
+  interface CubeFace {
+    points: string;
+    face: "top" | "left" | "right";
+    key: string;
+  }
+
+  // Collect only the visible shell faces, painted back-to-front
+  $: allFaces = (() => {
+    const faces: CubeFace[] = [];
+    const toPoints = (pts: [number, number, number][]): string =>
+      pts.map(([x, y, z]) => `${isoX(x, y)},${isoY(x, y, z)}`).join(" ");
+
+    // Top faces (gz = height - 1)
+    for (let gy = 0; gy < depth; gy++) {
+      for (let gx = 0; gx < width; gx++) {
+        const gz = height - 1;
+        faces.push({
+          points: toPoints([[gx, gy, gz + 1], [gx + 1, gy, gz + 1], [gx + 1, gy + 1, gz + 1], [gx, gy + 1, gz + 1]]),
+          face: "top",
+          key: `t-${gx}-${gy}-${gz}`,
+        });
+      }
+    }
+
+    // Left faces (gy = depth - 1)
+    for (let gz = 0; gz < height; gz++) {
+      for (let gx = 0; gx < width; gx++) {
+        const gy = depth - 1;
+        faces.push({
+          points: toPoints([[gx, gy + 1, gz + 1], [gx + 1, gy + 1, gz + 1], [gx + 1, gy + 1, gz], [gx, gy + 1, gz]]),
+          face: "left",
+          key: `l-${gx}-${gy}-${gz}`,
+        });
+      }
+    }
+
+    // Right faces (gx = width - 1)
+    for (let gz = 0; gz < height; gz++) {
+      for (let gy = 0; gy < depth; gy++) {
+        const gx = width - 1;
+        faces.push({
+          points: toPoints([[gx + 1, gy, gz + 1], [gx + 1, gy + 1, gz + 1], [gx + 1, gy + 1, gz], [gx + 1, gy, gz]]),
+          face: "right",
+          key: `r-${gx}-${gy}-${gz}`,
+        });
+      }
+    }
+
+    return faces;
+  })();
+
+  // Compute SVG viewBox from actual bounding box of the isometric projection
+  // Extremes: leftmost = isoX(0, depth), rightmost = isoX(width, 0)
+  //           topmost  = isoY(0, 0, height), bottommost = isoY(width, depth, 0)
+  $: minX = -depth * cell * COS30;
+  $: maxX = width * cell * COS30;
+  $: minY = -height * cell;
+  $: maxY = (width + depth) * cell * SIN30;
+  $: padX = 20;
+  $: padY = 16;
+  $: vbX = minX - padX;
+  $: vbY = minY - padY;
+  $: vbW = (maxX - minX) + padX * 2;
+  $: vbH = (maxY - minY) + padY * 2;
+</script>
+
+<div class="pit-preview" aria-label="Charcoal pit: {width}×{depth}×{height} blocks">
+  <div class="preview-stage">
+    <svg
+      viewBox="{vbX} {vbY} {vbW} {vbH}"
+      preserveAspectRatio="xMidYMid meet"
+      class="voxel-svg"
+      role="img"
+      aria-label="{width} wide, {depth} deep, {height} high"
+    >
+      {#each allFaces as f (f.key)}
+        <polygon class="voxel-face voxel-{f.face}" points={f.points} />
+      {/each}
+    </svg>
+  </div>
+  <div class="dim-badges">
+    <span class="dim-badge">{width}W</span>
+    <span class="dim-sep">×</span>
+    <span class="dim-badge">{depth}D</span>
+    <span class="dim-sep">×</span>
+    <span class="dim-badge">{height}H</span>
+  </div>
+</div>
+
+<style>
+  .pit-preview {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: calc(0.5rem * var(--ui-scale, 1));
+    width: 100%;
+  }
+
+  .preview-stage {
+    width: 100%;
+    height: 320px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+  }
+
+  .voxel-svg {
+    width: 100%;
+    height: 100%;
+    display: block;
+  }
+
+  .voxel-face {
+    stroke: var(--border-color, #ccc);
+    stroke-width: 0.5;
+    vector-effect: non-scaling-stroke;
+  }
+
+  .voxel-top {
+    fill: var(--primary-light, #4f7a57);
+    fill-opacity: 0.5;
+  }
+
+  .voxel-left {
+    fill: var(--primary-color, #335f3b);
+    fill-opacity: 0.7;
+  }
+
+  .voxel-right {
+    fill: var(--primary-dark, #1b3a20);
+    fill-opacity: 0.8;
+  }
+
+  .dim-badges {
+    display: flex;
+    gap: 0.4rem;
+    align-items: center;
+  }
+
+  .dim-badge {
+    font-family: var(--font-display, sans-serif);
+    font-weight: 600;
+    font-size: calc(0.85rem * var(--ui-scale, 1));
+    color: var(--text-secondary, #666);
+    background: var(--surface-muted, rgba(0,0,0,0.05));
+    padding: 0.15em 0.55em;
+    border-radius: 4px;
+  }
+
+  .dim-sep {
+    color: var(--text-secondary, #666);
+    font-size: 0.75rem;
+  }
+</style>

--- a/src/data/charcoal.json
+++ b/src/data/charcoal.json
@@ -1,0 +1,14 @@
+{
+  "firewoodPerLog": 4,
+  "firewoodPerStack": 32,
+  "charcoalPerStack": {
+    "min": 4,
+    "max": 7,
+    "avg": 5.5
+  },
+  "maxPitDimension": 11,
+  "minPitDimension": 1,
+  "burnTimeGameHours": 18,
+  "defaultRealMinutesPerGameDay": 60,
+  "gameHoursPerDay": 24
+}

--- a/src/lib/charcoal.ts
+++ b/src/lib/charcoal.ts
@@ -1,0 +1,92 @@
+import charcoalData from "../data/charcoal.json";
+
+const {
+  firewoodPerLog,
+  firewoodPerStack,
+  charcoalPerStack,
+  maxPitDimension,
+  minPitDimension,
+  burnTimeGameHours,
+  defaultRealMinutesPerGameDay,
+  gameHoursPerDay
+} = charcoalData;
+
+export {
+  firewoodPerLog,
+  firewoodPerStack,
+  charcoalPerStack,
+  maxPitDimension,
+  minPitDimension,
+  burnTimeGameHours
+};
+
+// Maximum charcoal obtainable from the largest pit (11³ × avg yield)
+export const maxPossibleCharcoal = Math.floor(
+  maxPitDimension ** 3 * charcoalPerStack.avg
+);
+
+export interface CharcoalResult {
+  volume: number;
+  totalFirewoodStacks: number;
+  totalFirewood: number;
+  totalLogs: number;
+  charcoalMin: number;
+  charcoalMax: number;
+  charcoalAvg: number;
+  burnTimeGameHours: number;
+  burnTimeRealMinutes: number;
+}
+
+export interface SuggestedPit {
+  width: number;
+  depth: number;
+  height: number;
+  volume: number;
+}
+
+const burnTimeRealMinutes =
+  (burnTimeGameHours / gameHoursPerDay) * defaultRealMinutesPerGameDay;
+
+export function calculateFromDimensions(
+  width: number,
+  depth: number,
+  height: number
+): CharcoalResult {
+  const w = width;
+  const d = depth;
+  const h = height;
+  const volume = w * d * h;
+
+  const totalFirewoodStacks = volume;
+  const totalFirewood = totalFirewoodStacks * firewoodPerStack;
+  const totalLogs = totalFirewood / firewoodPerLog;
+
+  return {
+    volume,
+    totalFirewoodStacks,
+    totalFirewood,
+    totalLogs,
+    charcoalMin: totalFirewoodStacks * charcoalPerStack.min,
+    charcoalMax: totalFirewoodStacks * charcoalPerStack.max,
+    charcoalAvg: totalFirewoodStacks * charcoalPerStack.avg,
+    burnTimeGameHours,
+    burnTimeRealMinutes
+  };
+}
+
+export function suggestPitDimensions(targetCharcoal: number): SuggestedPit {
+  const stacksNeeded = Math.ceil(
+    Math.max(1, targetCharcoal) / charcoalPerStack.avg
+  );
+
+  const maxVolume = maxPitDimension ** 3;
+  const clampedStacks = Math.min(stacksNeeded, maxVolume);
+
+  // Find the smallest roughly-cubic pit that fits the needed stacks
+  const side = Math.ceil(Math.cbrt(clampedStacks));
+  const w = Math.min(side, maxPitDimension);
+  const d = Math.min(Math.ceil(Math.sqrt(clampedStacks / w)), maxPitDimension);
+  const h = Math.min(Math.ceil(clampedStacks / (w * d)), maxPitDimension);
+
+  return { width: w, depth: d, height: h, volume: w * d * h };
+}

--- a/src/routes/CharcoalCalculator.svelte
+++ b/src/routes/CharcoalCalculator.svelte
@@ -1,0 +1,291 @@
+<script lang="ts">
+  import CalculatorCard from "../components/calculator-card.svelte";
+  import ModeToggle from "../components/mode-toggle.svelte";
+  import NumberInput from "../components/number-input.svelte";
+  import ShareButton from "../components/share-button.svelte";
+  import PitPreview from "../components/pit-preview.svelte";
+  import { formatWholeNumber } from "../lib/numberFormatting";
+  import {
+    firewoodPerLog,
+    firewoodPerStack,
+    charcoalPerStack,
+    maxPitDimension,
+    minPitDimension,
+    maxPossibleCharcoal
+  } from "../lib/charcoal";
+  import {
+    charcoalCalculation,
+    charcoalCalculator,
+    setMode,
+    setWidth,
+    setDepth,
+    setHeight,
+    setTargetCharcoal
+  } from "../stores/charcoalCalculator";
+  import type { CalculationMode } from "../types/index";
+
+  const formatQuantity = formatWholeNumber;
+
+  const formatDecimal = (value: number): string => {
+    if (Number.isInteger(value)) return String(value);
+    return value.toFixed(1);
+  };
+
+  const handleModeChange = (event: CustomEvent<{ value: CalculationMode }>) => {
+    setMode(event.detail.value);
+  };
+
+  const handleWidthInput = (event: CustomEvent<{ value: number | null }>) => {
+    setWidth(event.detail.value);
+  };
+
+  const handleDepthInput = (event: CustomEvent<{ value: number | null }>) => {
+    setDepth(event.detail.value);
+  };
+
+  const handleHeightInput = (event: CustomEvent<{ value: number | null }>) => {
+    setHeight(event.detail.value);
+  };
+
+  const handleTargetInput = (event: CustomEvent<{ value: number | null }>) => {
+    setTargetCharcoal(event.detail.value);
+  };
+</script>
+
+<section class="calculator-shell">
+  <aside class="calculator-rail" aria-label="Charcoal calculator controls">
+    <CalculatorCard
+      title="Charcoal Calculator"
+      subtitle="Charcoal pit planning"
+    >
+      <p>
+        {#if $charcoalCalculator.mode === "have"}
+          Enter pit dimensions to calculate firewood and logs needed, plus
+          expected charcoal yield.
+        {:else}
+          Enter your target charcoal amount and get a suggested pit size with
+          resource requirements.
+        {/if}
+      </p>
+    </CalculatorCard>
+
+    <div class="controls">
+      <ModeToggle
+        mode={$charcoalCalculator.mode}
+        needLabel="I need charcoal"
+        haveLabel="I have a pit"
+        on:change={handleModeChange}
+      />
+
+      {#if $charcoalCalculator.mode === "have"}
+        <NumberInput
+          id="pitWidth"
+          label="Width"
+          value={$charcoalCalculator.width}
+          min={minPitDimension}
+          max={maxPitDimension}
+          step={1}
+          helpText="Pit width in blocks ({minPitDimension}–{maxPitDimension})."
+          on:input={handleWidthInput}
+        />
+        <NumberInput
+          id="pitDepth"
+          label="Depth"
+          value={$charcoalCalculator.depth}
+          min={minPitDimension}
+          max={maxPitDimension}
+          step={1}
+          helpText="Pit depth in blocks ({minPitDimension}–{maxPitDimension})."
+          on:input={handleDepthInput}
+        />
+        <NumberInput
+          id="pitHeight"
+          label="Height"
+          value={$charcoalCalculator.height}
+          min={minPitDimension}
+          max={maxPitDimension}
+          step={1}
+          helpText="Pit height in blocks ({minPitDimension}–{maxPitDimension})."
+          on:input={handleHeightInput}
+        />
+      {:else}
+        <NumberInput
+          id="targetCharcoal"
+          label="Target charcoal"
+          value={$charcoalCalculator.targetCharcoal}
+          min={1}
+          max={maxPossibleCharcoal}
+          step={1}
+          helpText="How much charcoal you want to produce (max {maxPossibleCharcoal})."
+          on:input={handleTargetInput}
+        />
+      {/if}
+    </div>
+
+    <CalculatorCard title="Quick Summary" headingTag="h3">
+      <div class="calculator-meta-grid">
+        <p class="calculator-meta-item">
+          <span>Pit volume</span>
+          <strong>{formatQuantity($charcoalCalculation.volume)} blocks</strong>
+        </p>
+        <p class="calculator-meta-item">
+          <span>Firewood stacks</span>
+          <strong>{formatQuantity($charcoalCalculation.totalFirewoodStacks)}</strong>
+        </p>
+        <p class="calculator-meta-item charcoal-avg">
+          <span>Avg charcoal</span>
+          <strong>{formatDecimal($charcoalCalculation.charcoalAvg)}</strong>
+        </p>
+        <p class="calculator-meta-item">
+          <span>Burn time</span>
+          <strong>{$charcoalCalculation.burnTimeGameHours}h / {$charcoalCalculation.burnTimeRealMinutes}m</strong>
+        </p>
+      </div>
+    </CalculatorCard>
+
+    <ShareButton route="charcoal" />
+  </aside>
+
+  <section class="calculator-workspace" aria-label="Charcoal calculator results">
+    <div id="calculator" class="calculator-main">
+      {#if $charcoalCalculator.mode === "need"}
+        <CalculatorCard title="Suggested Pit Size" headingTag="h3">
+          <p class="suggested-note">
+            To produce ~{formatQuantity($charcoalCalculator.targetCharcoal)} charcoal
+            (using average yield of {charcoalPerStack.avg}/stack), you need at least:
+          </p>
+          <div class="suggested-dims">
+            <span class="suggested-dim">{$charcoalCalculation.pitWidth}</span>
+            <span class="suggested-sep">&times;</span>
+            <span class="suggested-dim">{$charcoalCalculation.pitDepth}</span>
+            <span class="suggested-sep">&times;</span>
+            <span class="suggested-dim">{$charcoalCalculation.pitHeight}</span>
+          </div>
+        </CalculatorCard>
+      {/if}
+
+      <CalculatorCard title="Resources Required" headingTag="h3">
+        <div class="calculator-meta-grid charcoal-resources-grid">
+          <p class="calculator-meta-item">
+            <span>Logs to chop</span>
+            <strong>{formatQuantity($charcoalCalculation.totalLogs)}</strong>
+          </p>
+          <p class="calculator-meta-item">
+            <span>Total firewood</span>
+            <strong>{formatQuantity($charcoalCalculation.totalFirewood)}</strong>
+          </p>
+          <p class="calculator-meta-item">
+            <span>Firewood stacks</span>
+            <strong>{formatQuantity($charcoalCalculation.totalFirewoodStacks)} × {firewoodPerStack}</strong>
+          </p>
+        </div>
+      </CalculatorCard>
+
+      <CalculatorCard title="Charcoal Output &amp; Burn Time" headingTag="h3">
+        <div class="calculator-meta-grid charcoal-yield-grid">
+          <p class="calculator-meta-item">
+            <span>Min yield</span>
+            <strong>{formatQuantity($charcoalCalculation.charcoalMin)}</strong>
+          </p>
+          <p class="calculator-meta-item charcoal-avg">
+            <span>Avg charcoal</span>
+            <strong>{formatDecimal($charcoalCalculation.charcoalAvg)}</strong>
+          </p>
+          <p class="calculator-meta-item">
+            <span>Max yield</span>
+            <strong>{formatQuantity($charcoalCalculation.charcoalMax)}</strong>
+          </p>
+          <p class="calculator-meta-item">
+            <span>Game time</span>
+            <strong>{$charcoalCalculation.burnTimeGameHours}h</strong>
+          </p>
+          <p class="calculator-meta-item">
+            <span>Real time</span>
+            <strong>{$charcoalCalculation.burnTimeRealMinutes} min</strong>
+          </p>
+        </div>
+      </CalculatorCard>
+
+      <CalculatorCard title="Pit Preview" headingTag="h3">
+        <PitPreview
+          width={$charcoalCalculation.pitWidth}
+          depth={$charcoalCalculation.pitDepth}
+          height={$charcoalCalculation.pitHeight}
+        />
+      </CalculatorCard>
+
+      <div class="charcoal-tip">
+        <strong>Tip:</strong> After lighting the firepit on top of the pit,
+        you have <strong>30 seconds</strong> to seal it completely with
+        non-combustible blocks (dirt, stone, etc.) or the process will fail.
+        All firewood stacks must be full ({firewoodPerStack} each), partial
+        stacks produce nothing.
+      </div>
+    </div>
+  </section>
+</section>
+
+<style>
+  .charcoal-resources-grid {
+    grid-template-columns: 1fr 1fr 1fr;
+  }
+
+  .charcoal-yield-grid {
+    grid-template-columns: repeat(3, 1fr);
+  }
+
+  .charcoal-avg {
+    border-color: var(--primary-color);
+  }
+
+  .charcoal-avg strong {
+    font-size: 1.15rem;
+    color: var(--primary-color);
+  }
+
+  .suggested-note {
+    margin: 0 0 0.5rem;
+    color: var(--text-secondary);
+  }
+
+  .suggested-dims {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.5rem;
+    padding: 0.75rem 0;
+  }
+
+  .suggested-dim {
+    font-family: var(--font-display);
+    font-size: calc(2rem * var(--ui-scale, 1));
+    font-weight: 700;
+    color: var(--primary-color);
+  }
+
+  .suggested-sep {
+    font-size: calc(1.5rem * var(--ui-scale, 1));
+    color: var(--text-secondary);
+  }
+
+  .charcoal-tip {
+    padding: calc(0.75rem * var(--ui-scale, 1));
+    background: var(--surface-muted);
+    border-left: 3px solid var(--primary-color);
+    border-radius: 4px;
+    font-size: calc(0.9rem * var(--ui-scale, 1));
+    color: var(--text-secondary);
+    line-height: 1.5;
+  }
+
+  .charcoal-tip strong {
+    color: var(--text-primary);
+  }
+
+  @media (max-width: 600px) {
+    .charcoal-resources-grid,
+    .charcoal-yield-grid {
+      grid-template-columns: 1fr 1fr;
+    }
+  }
+</style>

--- a/src/routes/Home.svelte
+++ b/src/routes/Home.svelte
@@ -1,9 +1,11 @@
 <section class="hero">
-  <p class="hero-kicker">Open source &middot; No accounts &middot; Always free</p>
-  <h2 class="hero-headline">Do the maths,<br>skip the guesswork.</h2>
+  <p class="hero-kicker">
+    Open source &middot; No accounts &middot; Always free
+  </p>
+  <h2 class="hero-headline">Do the maths,<br />skip the guesswork.</h2>
   <p class="hero-lead">
-    Precise calculators for Vintage Story &middot; alloy ratios, ingot casting, smelting
-    temperatures. Everything you need before you light the forge.
+    Precise calculators for Vintage Story &middot; alloy ratios, ingot casting,
+    smelting temperatures. Everything you need before you light the forge.
   </p>
   <div class="hero-actions">
     <a href="#alloying" class="btn-primary">Alloying Calculator</a>
@@ -19,8 +21,9 @@
       <div class="tool-body">
         <h3>Alloying Calculator</h3>
         <p>
-          Set a target ingot count and get exact nugget amounts for every alloy component.
-          Supports Tin Bronze, Black Bronze, Bismuth Bronze, Electrum, and more.
+          Set a target ingot count and get exact nugget amounts for every alloy
+          component. Supports Tin Bronze, Black Bronze, Bismuth Bronze,
+          Electrum, and more.
         </p>
       </div>
       <span class="tool-arrow" aria-hidden="true">→</span>
@@ -30,8 +33,9 @@
       <div class="tool-body">
         <h3>Casting Calculator</h3>
         <p>
-          Work out how many ore nuggets you need to cast a given number of ingots. Shows
-          smelting temperatures and ore sources for all castable metals.
+          Work out how many ore nuggets you need to cast a given number of
+          ingots. Shows smelting temperatures and ore sources for all castable
+          metals.
         </p>
       </div>
       <span class="tool-arrow" aria-hidden="true">→</span>
@@ -47,22 +51,40 @@
       </div>
       <span class="tool-arrow" aria-hidden="true">→</span>
     </a>
-        <a href="#feedback" class="tool-card">
-      <div class="tool-icon" aria-hidden="true">✉️</div>
+    <a href="#charcoal" class="tool-card">
+      <div class="tool-icon" aria-hidden="true">🔥</div>
       <div class="tool-body">
-        <h3>Feedback</h3>
+        <h3>Charcoal Calculator</h3>
         <p>
-          Share bugs, ideas, and balancing notes through a simple form. No account required.
+          Plan your charcoal production with precision. Calculate firewood needs,
+          expected charcoal yield, and optimal pit dimensions.
         </p>
       </div>
       <span class="tool-arrow" aria-hidden="true">→</span>
     </a>
-    <a href="https://wiki.vintagestory.at/Main_Page" class="tool-card" target="_blank" rel="noopener noreferrer">
+    <a href="#feedback" class="tool-card">
+      <div class="tool-icon" aria-hidden="true">✉️</div>
+      <div class="tool-body">
+        <h3>Feedback</h3>
+        <p>
+          Share bugs, ideas, and balancing notes through a simple form. No
+          account required.
+        </p>
+      </div>
+      <span class="tool-arrow" aria-hidden="true">→</span>
+    </a>
+    <a
+      href="https://wiki.vintagestory.at/Main_Page"
+      class="tool-card"
+      target="_blank"
+      rel="noopener noreferrer"
+    >
       <div class="tool-icon" aria-hidden="true">📚</div>
       <div class="tool-body">
         <h3>VS Wiki</h3>
         <p>
-          Check out the Vintage Story Wiki for detailed info on ores, alloys, smelting, and more. An invaluable resource for any player!
+          Check out the Vintage Story Wiki for detailed info on ores, alloys,
+          smelting, and more. An invaluable resource for any player!
         </p>
       </div>
       <span class="tool-arrow" aria-hidden="true">→</span>
@@ -71,6 +93,9 @@
 </section>
 
 <div class="home-footer-note">
-  <p>Built by a player, for players. Source code on <a href="https://github.com/D-Heger/VintageStoryCalculator">GitHub</a>.</p>
+  <p>
+    Built by a player, for players. Source code on <a
+      href="https://github.com/D-Heger/VintageStoryCalculator">GitHub</a
+    >.
+  </p>
 </div>
-

--- a/src/stores/charcoalCalculator.ts
+++ b/src/stores/charcoalCalculator.ts
@@ -1,0 +1,112 @@
+import { derived, writable } from "svelte/store";
+import {
+  calculateFromDimensions,
+  suggestPitDimensions,
+  maxPitDimension,
+  minPitDimension
+} from "../lib/charcoal";
+import type { CalculationMode } from "../types/index";
+
+const DEFAULT_DIMENSION = 3;
+const DEFAULT_TARGET_CHARCOAL = 100;
+
+export type CharcoalCalculatorState = {
+  mode: CalculationMode;
+  width: number;
+  depth: number;
+  height: number;
+  targetCharcoal: number;
+};
+
+const clamp = (value: number, min: number, max: number) =>
+  Math.max(min, Math.min(max, Math.floor(value)));
+
+const initializeState = (): CharcoalCalculatorState => ({
+  mode: "have",
+  width: DEFAULT_DIMENSION,
+  depth: DEFAULT_DIMENSION,
+  height: DEFAULT_DIMENSION,
+  targetCharcoal: DEFAULT_TARGET_CHARCOAL
+});
+
+export const charcoalCalculator = writable<CharcoalCalculatorState>(
+  initializeState()
+);
+
+export const setMode = (mode: CalculationMode) => {
+  charcoalCalculator.update((state) => {
+    if (state.mode === mode) return state;
+    return { ...state, mode };
+  });
+};
+
+export const setWidth = (value: number | null) => {
+  const safe = clamp(Number(value) || minPitDimension, minPitDimension, maxPitDimension);
+  charcoalCalculator.update((state) => ({ ...state, width: safe }));
+};
+
+export const setDepth = (value: number | null) => {
+  const safe = clamp(Number(value) || minPitDimension, minPitDimension, maxPitDimension);
+  charcoalCalculator.update((state) => ({ ...state, depth: safe }));
+};
+
+export const setHeight = (value: number | null) => {
+  const safe = clamp(Number(value) || minPitDimension, minPitDimension, maxPitDimension);
+  charcoalCalculator.update((state) => ({ ...state, height: safe }));
+};
+
+export const setTargetCharcoal = (value: number | null) => {
+  const safe = Math.max(1, Math.floor(Number(value) || 1));
+  charcoalCalculator.update((state) => ({ ...state, targetCharcoal: safe }));
+};
+
+export const applyState = (partial: Partial<CharcoalCalculatorState>) => {
+  charcoalCalculator.update((state) => {
+    const next = { ...state };
+
+    if (partial.mode !== undefined) {
+      next.mode = partial.mode === "need" ? "need" : "have";
+    }
+    if (partial.width !== undefined) {
+      next.width = clamp(Number(partial.width) || minPitDimension, minPitDimension, maxPitDimension);
+    }
+    if (partial.depth !== undefined) {
+      next.depth = clamp(Number(partial.depth) || minPitDimension, minPitDimension, maxPitDimension);
+    }
+    if (partial.height !== undefined) {
+      next.height = clamp(Number(partial.height) || minPitDimension, minPitDimension, maxPitDimension);
+    }
+    if (partial.targetCharcoal !== undefined) {
+      next.targetCharcoal = Math.max(1, Math.floor(Number(partial.targetCharcoal) || 1));
+    }
+
+    return next;
+  });
+};
+
+export const charcoalCalculation = derived(charcoalCalculator, (state) => {
+  if (state.mode === "need") {
+    const suggested = suggestPitDimensions(state.targetCharcoal);
+    const result = calculateFromDimensions(
+      suggested.width,
+      suggested.depth,
+      suggested.height
+    );
+    return {
+      mode: state.mode,
+      pitWidth: suggested.width,
+      pitDepth: suggested.depth,
+      pitHeight: suggested.height,
+      ...result
+    };
+  }
+
+  const result = calculateFromDimensions(state.width, state.depth, state.height);
+  return {
+    mode: state.mode,
+    pitWidth: state.width,
+    pitDepth: state.depth,
+    pitHeight: state.height,
+    ...result
+  };
+});

--- a/src/stores/share/charcoalCodec.ts
+++ b/src/stores/share/charcoalCodec.ts
@@ -1,0 +1,65 @@
+import { get } from "svelte/store";
+import { registerShareCodec } from "../../lib/url-state";
+import {
+  applyState,
+  charcoalCalculator,
+  type CharcoalCalculatorState
+} from "../charcoalCalculator";
+
+export function registerCharcoalShareCodec(): void {
+  registerShareCodec("charcoal", {
+    encode() {
+      const state = get(charcoalCalculator);
+      const params = new URLSearchParams();
+      if (state.mode === "have") {
+        params.set("d", "h");
+        params.set("w", String(state.width));
+        params.set("dp", String(state.depth));
+        params.set("h", String(state.height));
+      } else {
+        params.set("c", String(state.targetCharcoal));
+      }
+      return params;
+    },
+    apply(params) {
+      const partial: Partial<CharcoalCalculatorState> = {};
+
+      const direction = params.get("d");
+      if (direction === "h") {
+        partial.mode = "have";
+        const w = params.get("w");
+        if (w !== null) {
+          const value = Number(w);
+          if (Number.isFinite(value) && value >= 1) {
+            partial.width = value;
+          }
+        }
+        const dp = params.get("dp");
+        if (dp !== null) {
+          const value = Number(dp);
+          if (Number.isFinite(value) && value >= 1) {
+            partial.depth = value;
+          }
+        }
+        const h = params.get("h");
+        if (h !== null) {
+          const value = Number(h);
+          if (Number.isFinite(value) && value >= 1) {
+            partial.height = value;
+          }
+        }
+      } else {
+        partial.mode = "need";
+        const c = params.get("c");
+        if (c !== null) {
+          const value = Number(c);
+          if (Number.isFinite(value) && value >= 1) {
+            partial.targetCharcoal = Math.floor(value);
+          }
+        }
+      }
+
+      applyState(partial);
+    }
+  });
+}

--- a/src/stores/share/index.ts
+++ b/src/stores/share/index.ts
@@ -1,4 +1,5 @@
 import { registerAlloyShareCodec } from "./alloyCodec";
+import { registerCharcoalShareCodec } from "./charcoalCodec";
 import { registerMetalShareCodec } from "./metalCodec";
 import { registerUsageShareCodec } from "./usageCodec";
 
@@ -7,6 +8,7 @@ let initialized = false;
 export function setupShareCodecs(): void {
   if (initialized) return;
   registerAlloyShareCodec();
+  registerCharcoalShareCodec();
   registerMetalShareCodec();
   registerUsageShareCodec();
   initialized = true;


### PR DESCRIPTION
- Introduced Charcoal Calculator tool for calculating pit dimensions, firewood needs, and charcoal yield.
- Added interactive 3D isometric pit preview component.
- Implemented bidirectional calculation support for "I have a pit" and "I need charcoal" modes.
- Configurable button labels for context-specific wording in mode toggle.
- Added shareable URLs for saved configurations with a new codec.
- Included burn time calculations in both game hours and real-world minutes.
- Created a charcoal data definitions module for constants and ratios.
- Updated home page and navigation to feature the new calculator.