### PR TITLE
Fix card heading divider spacing in calculator sections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added base dependabot configuration for automated dependency updates with weekly schedule and PRs targeting the `master` branch
 - Added basic ci gate for pull requests that runs `npm install` and `npm run build` to catch build errors before merging into `master` or another protected branch
 
+### Fixed
+
+- Added consistent spacing below reusable card heading divider lines so section content no longer sits too close to the border
+
 ### Changed
 
 - Updated release workflow to use latest versions of `actions/checkout` and `actions/setup-node`, and node.js
@@ -22,10 +26,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bumped `flatted` from 3.3.3 to 3.4.2, ref [changes](https://github.com/D-Heger/VintageStoryCalculator/commit/ff4b956af885e756625d03a7f49e209aab235531)
 - Bumped `picomatch` from 2.3.1 to 2.3.2, ref [changes](https://github.com/D-Heger/VintageStoryCalculator/commit/89ba483d9f27d71770edc2deadd94370ccde537c)
 - Bumped `rollup` from 4.53.3 to 4.60.2, ref [changes](https://github.com/D-Heger/VintageStoryCalculator/commit/4056c3c326e46051aefd5fc5555e35f174b13011)
-
-### Fixed
-
-- Added consistent spacing below reusable card heading divider lines so section content no longer sits too close to the border
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bumped `picomatch` from 2.3.1 to 2.3.2, ref [changes](https://github.com/D-Heger/VintageStoryCalculator/commit/89ba483d9f27d71770edc2deadd94370ccde537c)
 - Bumped `rollup` from 4.53.3 to 4.60.2, ref [changes](https://github.com/D-Heger/VintageStoryCalculator/commit/4056c3c326e46051aefd5fc5555e35f174b13011)
 
+### Fixed
+
+- Added consistent spacing below reusable card heading divider lines so section content no longer sits too close to the border
+
 ### Removed
 
 - Removed variable getCompatibleFuels from alloyCalculator.ts since it was not being used anymore after refactoring fuel details to getIngredientFuelDetails

--- a/styles/components.css
+++ b/styles/components.css
@@ -21,6 +21,7 @@
   margin-top: 0;
   border-bottom: 1px solid var(--border-color);
   padding-bottom: var(--spacing-xs);
+  margin-bottom: var(--spacing-sm);
   color: var(--text-primary);
 }
 
@@ -28,6 +29,7 @@
   margin-top: 0;
   border-bottom: 1px solid var(--border-color);
   padding-bottom: var(--spacing-xs);
+  margin-bottom: var(--spacing-sm);
 }
 
 .card > p {


### PR DESCRIPTION
## Summary
- add consistent bottom spacing below reusable `card` headings (`h2` and `h3`) so divider lines do not crowd section content
- apply fix centrally in shared component styles to avoid route-specific overrides
- add an Unreleased changelog entry under **Fixed** describing the spacing correction

## Validation
- built project successfully with `npm run build`
- verified in browser on:
  - `#charcoal` (Resources Required / Charcoal Output & Burn Time)
  - `#alloying` (Quick Summary)
  - `#casting` (Quick Summary)

## Files Changed
- `styles/components.css`
- `CHANGELOG.md`