### PR TITLE
fix: remove redundant home hero buttons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Removed the two redundant hero CTA buttons from the home page now that the same destinations are already covered by the tool cards below
 - Updated release workflow to use latest versions of `actions/checkout` and `actions/setup-node`, and node.js
 - Replaced deprecated `actions/create-release` with `softprops/action-gh-release`
 - Migrated ESLint from v8 (`.eslintrc.cjs`) to v10 with flat config (`eslint.config.js`), replacing `@typescript-eslint/eslint-plugin` and `@typescript-eslint/parser` with `typescript-eslint` and adding `@eslint/js` and `globals`
@@ -31,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 - Removed variable getCompatibleFuels from alloyCalculator.ts since it was not being used anymore after refactoring fuel details to getIngredientFuelDetails
+- Removed the two redundant hero CTA buttons from the home page now that the same destinations are already covered by the tool cards below
 
 ## [0.7.0] - 2026-04-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Removed the two redundant hero CTA buttons from the home page now that the same destinations are already covered by the tool cards below
 - Updated release workflow to use latest versions of `actions/checkout` and `actions/setup-node`, and node.js
 - Replaced deprecated `actions/create-release` with `softprops/action-gh-release`
 - Migrated ESLint from v8 (`.eslintrc.cjs`) to v10 with flat config (`eslint.config.js`), replacing `@typescript-eslint/eslint-plugin` and `@typescript-eslint/parser` with `typescript-eslint` and adding `@eslint/js` and `globals`

--- a/src/routes/Home.svelte
+++ b/src/routes/Home.svelte
@@ -7,10 +7,6 @@
     Precise calculators for Vintage Story &middot; alloy ratios, ingot casting,
     smelting temperatures. Everything you need before you light the forge.
   </p>
-  <div class="hero-actions">
-    <a href="#alloying" class="btn-primary">Alloying Calculator</a>
-    <a href="#casting" class="btn-outline">Casting Calculator</a>
-  </div>
 </section>
 
 <section class="tools-section">

--- a/styles/components.css
+++ b/styles/components.css
@@ -190,50 +190,6 @@
   max-width: 540px;
 }
 
-.hero-actions {
-  display: flex;
-  flex-wrap: wrap;
-  gap: var(--spacing-sm);
-  align-items: center;
-}
-
-.btn-primary {
-  display: inline-flex;
-  align-items: center;
-  padding: 10px 22px;
-  background: var(--primary-color);
-  color: white;
-  border-radius: var(--border-radius);
-  font-weight: 600;
-  font-size: 0.95rem;
-  transition: all var(--transition);
-}
-
-.btn-primary:hover {
-  background: var(--primary-dark);
-  transform: translateY(-1px);
-  box-shadow: 0 4px 14px var(--shadow-hover);
-}
-
-.btn-outline {
-  display: inline-flex;
-  align-items: center;
-  padding: 10px 22px;
-  background: transparent;
-  color: var(--primary-color);
-  border-radius: var(--border-radius);
-  font-weight: 600;
-  font-size: 0.95rem;
-  border: 2px solid var(--border-strong);
-  transition: all var(--transition);
-}
-
-.btn-outline:hover {
-  border-color: var(--primary-color);
-  background: var(--surface-muted);
-  transform: translateY(-1px);
-}
-
 .tools-section {
   margin-bottom: var(--spacing-lg);
 }


### PR DESCRIPTION
## Summary
- remove the two redundant CTA buttons from the home page hero
- keep the existing tool-card navigation as the primary entry point
- remove the now-unused hero button styles and note the cleanup in the changelog

## Validation
- npm run build
- verified in a browser that the home page no longer shows the two hero buttons
- verified in a browser that the Alloying tool card still navigates correctly from the home page