### PR TITLE
Add a standard pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/standard.md
+++ b/.github/PULL_REQUEST_TEMPLATE/standard.md
@@ -1,0 +1,47 @@
+## Summary
+
+<!-- Describe what changed and why. Keep this focused on reviewer context, not file inventory. -->
+
+## Type Of Change
+
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Improvement or refactor
+- [ ] Documentation
+- [ ] Build, CI, or tooling
+
+## Changes
+
+<!-- List the concrete changes worth calling out for review. -->
+
+- Describe the main code, UI, data, or workflow changes.
+
+## How To Test
+
+<!-- Provide enough detail for a reviewer to verify the change confidently. -->
+
+1. Set up the relevant state, page, or input data.
+2. Exercise the changed behavior.
+3. Confirm the expected result and check for regressions.
+
+## Screenshots
+
+<!-- Add before/after screenshots or recordings for UI changes, or remove this section if not applicable. -->
+
+## Risks And Follow-Up
+
+<!-- Note rollout concerns, known limitations, migrations, or planned follow-up work. -->
+
+- Risk: None beyond the changed area.
+- Follow-up: None.
+
+## Related Issues
+
+<!-- Use closing keywords when appropriate, for example: Fixes #123 -->
+
+## Checklist
+
+- [ ] I tested the changes locally or explained why testing was not needed.
+- [ ] I reviewed the diff for unrelated changes.
+- [ ] I updated documentation, screenshots, or release notes when needed.
+- [ ] I confirmed there are no new console errors or obvious regressions.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added base dependabot configuration for automated dependency updates with weekly schedule and PRs targeting the `master` branch
 - Added basic ci gate for pull requests that runs `npm install` and `npm run build` to catch build errors before merging into `master` or another protected branch
+- Added a standard pull request template under `.github/PULL_REQUEST_TEMPLATE/standard.md` with sections for change summary, testing, risks, and reviewer checklist
 
 ### Fixed
 


### PR DESCRIPTION
## Summary

Add a standard pull request template under `.github/PULL_REQUEST_TEMPLATE/standard.md` and record it in the unreleased changelog. The template is designed to improve review quality without adding noisy or overly prescriptive boilerplate.

## Type Of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Improvement or refactor
- [x] Documentation
- [ ] Build, CI, or tooling

## Changes

- Added a single standard PR template with sections for summary, change type, concrete changes, testing, screenshots, risks, related issues, and a final checklist.
- Added an unreleased changelog entry documenting the new PR template.

## How To Test

1. Open the new template at `.github/PULL_REQUEST_TEMPLATE/standard.md`.
2. Confirm the sections cover the information a reviewer needs without repo-specific noise.
3. Check `CHANGELOG.md` and verify the template addition is listed under `Unreleased`.

## Screenshots

Not applicable.

## Risks And Follow-Up

- Risk: Low. This change only adds repository documentation.
- Follow-up: None.

## Related Issues

None.

## Checklist

- [x] I tested the changes locally or explained why testing was not needed.
- [x] I reviewed the diff for unrelated changes.
- [x] I updated documentation, screenshots, or release notes when needed.
- [x] I confirmed there are no new console errors or obvious regressions.
