### PR TITLE
Add verified game version badges to calculators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added base dependabot configuration for automated dependency updates with weekly schedule and PRs targeting the `master` branch
 - Added basic ci gate for pull requests that runs `npm install` and `npm run build` to catch build errors before merging into `master` or another protected branch
 - Added a standard pull request template under `.github/PULL_REQUEST_TEMPLATE/standard.md` with sections for change summary, testing, risks, and reviewer checklist
+- Added per-tool verification badges to calculator intro cards so each tool shows the Vintage Story version its accuracy was last verified against
 
 ### Fixed
 

--- a/src/components/calculator-card.svelte
+++ b/src/components/calculator-card.svelte
@@ -3,6 +3,7 @@
 
   export let title: CalculatorCardProps["title"];
   export let subtitle: CalculatorCardProps["subtitle"] = "";
+  export let verifiedVersion: CalculatorCardProps["verifiedVersion"] = "";
   export let headingTag: CalculatorCardProps["headingTag"] = "h2";
   export let className: CalculatorCardProps["className"] = "";
 
@@ -16,8 +17,21 @@
 
 <div class={cardClassName}>
   <svelte:element this={headingTag}>{title}</svelte:element>
-  {#if subtitle}
-    <p>{subtitle}</p>
+  {#if subtitle || verifiedVersion}
+    <div class="card-meta">
+      {#if subtitle}
+        <span class="card-subtitle">{subtitle}</span>
+      {/if}
+      {#if verifiedVersion}
+        <span
+          class="card-info-badge"
+          aria-label={`Accuracy verified for Vintage Story ${verifiedVersion}`}
+          title={`Accuracy verified for Vintage Story ${verifiedVersion}`}
+        >
+          Verified for {verifiedVersion}
+        </span>
+      {/if}
+    </div>
   {/if}
   <slot />
 </div>

--- a/src/lib/toolVerification.ts
+++ b/src/lib/toolVerification.ts
@@ -1,0 +1,6 @@
+export const VERIFIED_TOOL_VERSIONS = {
+  alloying: "1.22",
+  casting: "1.22",
+  charcoal: "1.22",
+  usage: "1.22"
+} as const;

--- a/src/routes/AlloyingCalculator.svelte
+++ b/src/routes/AlloyingCalculator.svelte
@@ -8,6 +8,7 @@
   import alloyDefinitionsRaw from "../data/alloys.json";
   import { NUGGETS_PER_INGOT } from "../lib/constants";
   import { formatWholeNumber } from "../lib/numberFormatting";
+  import { VERIFIED_TOOL_VERSIONS } from "../lib/toolVerification";
   import {
     ALLOY_PERCENT_PRECISION,
     ALLOY_PERCENT_STEP,
@@ -61,6 +62,7 @@
     <CalculatorCard
       title="Alloying Calculator"
       subtitle="Blend planning"
+      verifiedVersion={VERIFIED_TOOL_VERSIONS.alloying}
     >
       <p>
         {#if $alloyCalculator.mode === "have"}

--- a/src/routes/CastingCalculator.svelte
+++ b/src/routes/CastingCalculator.svelte
@@ -8,6 +8,7 @@
   import metalDefinitionsRaw from "../data/metals.json";
   import { NUGGETS_PER_INGOT, UNITS_PER_INGOT } from "../lib/constants";
   import { formatWholeNumber } from "../lib/numberFormatting";
+  import { VERIFIED_TOOL_VERSIONS } from "../lib/toolVerification";
   import {
     metalCalculation,
     metalCalculator,
@@ -46,6 +47,7 @@
     <CalculatorCard
       title="Casting Calculator"
       subtitle="Ore to ingot planning"
+      verifiedVersion={VERIFIED_TOOL_VERSIONS.casting}
     >
       <p>
         {#if $metalCalculator.mode === "have"}

--- a/src/routes/CharcoalCalculator.svelte
+++ b/src/routes/CharcoalCalculator.svelte
@@ -5,6 +5,7 @@
   import ShareButton from "../components/share-button.svelte";
   import PitPreview from "../components/pit-preview.svelte";
   import { formatWholeNumber } from "../lib/numberFormatting";
+  import { VERIFIED_TOOL_VERSIONS } from "../lib/toolVerification";
   import {
     firewoodPerLog,
     firewoodPerStack,
@@ -57,6 +58,7 @@
     <CalculatorCard
       title="Charcoal Calculator"
       subtitle="Charcoal pit planning"
+      verifiedVersion={VERIFIED_TOOL_VERSIONS.charcoal}
     >
       <p>
         {#if $charcoalCalculator.mode === "have"}

--- a/src/routes/UsageFinder.svelte
+++ b/src/routes/UsageFinder.svelte
@@ -6,6 +6,7 @@
   import StackPlanPanel from "../components/stack-plan-panel.svelte";
   import { NUGGETS_PER_INGOT } from "../lib/constants";
   import { formatWholeNumber } from "../lib/numberFormatting";
+  import { VERIFIED_TOOL_VERSIONS } from "../lib/toolVerification";
   import {
     addMetal,
     allMetalKeys,
@@ -52,6 +53,7 @@
     <CalculatorCard
       title="Usage Finder"
       subtitle="What can I make?"
+      verifiedVersion={VERIFIED_TOOL_VERSIONS.usage}
     >
       <p>
         Add the metals you have and see everything you can craft. One ingot

--- a/src/types/components.ts
+++ b/src/types/components.ts
@@ -13,6 +13,7 @@ export type HeadingTag = "h2" | "h3" | "h4";
 export interface CalculatorCardProps {
   title: string;
   subtitle?: string;
+  verifiedVersion?: string;
   headingTag?: HeadingTag;
   className?: string;
 }

--- a/styles/components.css
+++ b/styles/components.css
@@ -32,6 +32,34 @@
   margin-bottom: var(--spacing-sm);
 }
 
+.card-meta {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: calc(var(--spacing-xs) * 0.9);
+  margin: 0 0 var(--spacing-sm) 0;
+}
+
+.card-subtitle {
+  color: var(--text-secondary);
+  font-size: 0.92rem;
+  line-height: 1.4;
+}
+
+.card-info-badge {
+  display: inline-flex;
+  align-items: center;
+  border: 1px solid var(--border-soft);
+  border-radius: 999px;
+  background: var(--surface-muted);
+  color: var(--text-secondary);
+  font-size: 0.78rem;
+  font-weight: 700;
+  line-height: 1;
+  padding: 0.38rem 0.65rem;
+  white-space: nowrap;
+}
+
 .card > p {
   margin: 0;
   color: var(--text-secondary);


### PR DESCRIPTION
## Summary

Add a verified-version badge to the shared calculator intro card so each calculator shows the Vintage Story version its accuracy was last checked against. This keeps the display consistent across tools and centralizes the version values for future updates.

## Type Of Change

- [ ] Bug fix
- [x] New feature
- [ ] Improvement or refactor
- [ ] Documentation
- [ ] Build, CI, or tooling

## Changes

- Added `VERIFIED_TOOL_VERSIONS` as a single source of truth for per-tool verification versions.
- Extended the shared `CalculatorCard` to render an optional verification badge alongside each calculator subtitle.
- Wired the badge into Alloying, Casting, Charcoal, and Usage Finder and added an unreleased changelog entry.

## How To Test

1. Run `npm run dev`.
2. Open `#alloying`, `#casting`, `#charcoal`, and `#usage`.
3. Confirm each calculator intro card shows `Verified for 1.22` and the header layout remains intact.
4. Run `npm run build` and confirm the build succeeds.

## Screenshots

Not included. This is a small calculator-header UI change that I verified locally in the browser.

## Risks And Follow-Up

- Risk: Badge values are manual and should be updated when a calculator is reverified against a newer Vintage Story version.
- Follow-up: None.

## Related Issues

None.

## Checklist

- [x] I tested the changes locally or explained why testing was not needed.
- [x] I reviewed the diff for unrelated changes.
- [x] I updated documentation, screenshots, or release notes when needed.
- [x] I confirmed there are no new console errors or obvious regressions.
